### PR TITLE
Fix issue that scopes with same name got overridden

### DIFF
--- a/lib/spyke/scopes.rb
+++ b/lib/spyke/scopes.rb
@@ -9,7 +9,7 @@ module Spyke
       delegate :all, :where, to: :current_scope
 
       def scope(name, code)
-        self.class.send :define_method, name, code
+        (class << self; self end).send :define_method, name, code
       end
 
       def current_scope=(scope)

--- a/test/relation_test.rb
+++ b/test/relation_test.rb
@@ -51,6 +51,16 @@ module Spyke
       assert_requested endpoint
     end
 
+    def test_scope_class_method_doesnt_get_overridden
+      recipe_endpoint = stub_request(:get, 'http://sushi.com/recipes?approved=true')
+      comment_endpoint = stub_request(:get, 'http://sushi.com/comments?comment_approved=true')
+
+      Recipe.approved.to_a
+      assert_requested recipe_endpoint
+      Comment.approved.to_a
+      assert_requested comment_endpoint
+    end
+
     def test_scope_doesnt_get_stuck
       endpoint_1 = stub_request(:get, 'http://sushi.com/recipes?per_page=3&status=published')
       endpoint_2 = stub_request(:get, 'http://sushi.com/recipes?status=published')

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -6,6 +6,7 @@ class Recipe < Spyke::Base
   belongs_to :user
 
   scope :published, -> { where(status: 'published') }
+  scope :approved, -> { where(approved: true) }
   attributes :title
 
   before_save :before_save_callback
@@ -62,4 +63,8 @@ end
 
 class Photo < Spyke::Base
   uri '/images/photos/:id'
+end
+
+class Comment < Spyke::Base
+  scope :approved, -> { where(comment_approved: true) }
 end


### PR DESCRIPTION
seems like scope methods are defined in one place and shared across all classes, so with same scope name it'll be overridden.

``` ruby
class Recipe < Spyke::Base
  scope :published, -> { where(status: 'published') }
end

class Comment < Spyke::Base
end

Comment.respond_to?(:published) 
# => true
Comment.published
# => #<Spyke::Relation:0x007ff668109058 @klass=Comment, @options={:uri=>"/comments/:id"}, @params={:status=>"published"}>
```
