### PR TITLE
Allow returned errors to be added to base

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ class JSONParser < Faraday::Response::Middleware
     json = MultiJson.load(body, symbolize_keys: true)
     {
       data: json[:result],
-      metadata: json[:metadata]
+      metadata: json[:metadata],
+      errors: [json[:message]]
     }
   rescue MultiJson::ParseError => exception
-    { error: exception.cause }
+    { errors: [exception.cause] }
   end
 end
 
@@ -70,19 +71,19 @@ class User < Spyke::Base
   has_many :posts
 end
 
-user = User.find(3) 
+user = User.find(3)
 # => GET http://api.com/users/3
 
-user.posts 
+user.posts
 # => find embedded in returned JSON or GET http://api.com/users/3/posts
 
-user.update_attributes(name: 'Alice') 
+user.update_attributes(name: 'Alice')
 # => PUT http://api.com/users/3 - { user: { name: 'Alice' } }
 
-user.destroy 
+user.destroy
 # => DELETE http://api.com/users/3
 
-User.create(name: 'Bob') 
+User.create(name: 'Bob')
 # => POST http://api.com/users - { user: { name: 'Bob' } }
 ```
 

--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -62,17 +62,27 @@ module Spyke
     METHODS.each do |method|
       define_method(method) do |action = nil, params = {}|
         params = action if action.is_a?(Hash)
-        path = case action
-               when Symbol then uri.join(action)
-               when String then Path.new(action, attributes)
-               else uri
-               end
-        self.attributes = self.class.send("#{method}_raw", path, params).data
+        path = resolve_path_from_action(action)
+
+        result = self.class.send("#{method}_raw", path, params)
+
+        result.errors.each { |error| errors.add(:base, error) }
+        self.attributes = result.data
       end
     end
 
     def uri
       Path.new(@uri_template, attributes)
     end
+
+    private
+
+      def resolve_path_from_action(action)
+        case action
+        when Symbol then uri.join(action)
+        when String then Path.new(action, attributes)
+        else uri
+        end
+      end
   end
 end

--- a/lib/spyke/result.rb
+++ b/lib/spyke/result.rb
@@ -19,7 +19,7 @@ module Spyke
     end
 
     def errors
-      body[:errors]
+      body[:errors] || []
     end
   end
 end

--- a/lib/spyke/version.rb
+++ b/lib/spyke/version.rb
@@ -1,3 +1,3 @@
 module Spyke
-  VERSION = '1.2.1'
+  VERSION = '1.3.0'
 end

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -79,6 +79,16 @@ module Spyke
       assert_requested endpoint
     end
 
+    def test_create_with_server_failure
+      endpoint = stub_request(:put, 'http://sushi.com/recipes/1').to_return_json(id: 'write_error:400', message: 'Unable to save recipe')
+
+      recipe = Recipe.create(id: 1, title: 'Sushi')
+
+      assert_equal 'Sushi', recipe.title
+      assert_equal ['Unable to save recipe'], recipe.errors[:base]
+      assert_requested endpoint
+    end
+
     def test_find_using_custom_uri_template
       endpoint = stub_request(:get, 'http://sushi.com/images/photos/1').to_return_json(result: { id: 1 })
       Photo.find(1)

--- a/test/support/api.rb
+++ b/test/support/api.rb
@@ -4,10 +4,11 @@ class JSONParser < Faraday::Response::Middleware
     json = MultiJson.load(body, symbolize_keys: true)
     {
       data: json[:result],
-      metadata: json[:metadata]
+      metadata: json[:metadata],
+      errors: [json[:message]]
     }
   rescue MultiJson::ParseError => exception
-    { error: exception.cause }
+    { errors: [exception.cause] }
   end
 end
 


### PR DESCRIPTION
Provides a way to assign errors from the API as part of `ActiveModel::Errors` so they can be displayed to the user.