### PR TITLE
Better handling of Spyke associations

### DIFF
--- a/lib/spyke/associations/association.rb
+++ b/lib/spyke/associations/association.rb
@@ -15,8 +15,19 @@ module Spyke
         find_one # Override for plural associations that return an association object
       end
 
+      def find_one
+        result = super
+        update_parent(result) if result
+      end
+
+      def find_some
+        result = super
+        update_parent(result) if result.any?
+        result
+      end
+
       def assign_nested_attributes(attributes)
-        parent.attributes[name] = new(attributes).attributes
+        update_parent new(attributes)
       end
 
       def create(attributes = {})
@@ -27,15 +38,12 @@ module Spyke
         add_to_parent super
       end
 
-      def build(*args)
-        new(*args)
-      end
+      alias :build :new
 
       private
 
         def add_to_parent(record)
-          parent.attributes[name] = record.attributes
-          record
+          update_parent record
         end
 
         def foreign_key
@@ -47,15 +55,19 @@ module Spyke
         end
 
         def fetch_embedded
-          if embedded_attributes
-            Result.new(data: embedded_attributes)
+          if embedded_params
+            Result.new(data: embedded_params)
           elsif !uri
             Result.new(data: nil)
           end
         end
 
-        def embedded_attributes
-          parent.attributes[name]
+        def embedded_params
+          @embedded_params ||= parent.attributes.to_params[name]
+        end
+
+        def update_parent(value)
+          parent.attributes[name] = value
         end
     end
   end

--- a/lib/spyke/attribute_assignment.rb
+++ b/lib/spyke/attribute_assignment.rb
@@ -1,0 +1,111 @@
+require 'spyke/collection'
+require 'spyke/attributes'
+
+module Spyke
+  module AttributeAssignment
+    extend ActiveSupport::Concern
+
+    included do
+      attr_reader :attributes
+    end
+
+    module ClassMethods
+      def attributes(*args)
+        args.each do |attr|
+          define_method attr do
+            attribute(attr)
+          end
+        end
+      end
+    end
+
+    def initialize(attributes = {})
+      self.attributes = attributes
+      @uri_template = scope.uri
+    end
+
+    def attributes=(new_attributes)
+      @attributes ||= Attributes.new(scope.params)
+      use_setters(new_attributes) if new_attributes
+    end
+
+    def id
+      attributes[:id]
+    end
+
+    def id=(value)
+      attributes[:id] = value if value.present?
+    end
+
+    def ==(other)
+      other.is_a?(Spyke::Base) && id == other.id
+    end
+
+    def inspect
+      "#<#{self.class}(#{uri}) id: #{id.inspect} #{inspect_attributes}>"
+    end
+
+    private
+
+      def use_setters(attributes)
+        attributes.each do |key, value|
+          send "#{key}=", value
+        end
+      end
+
+      def method_missing(name, *args, &block)
+        case
+        when association?(name) then association(name).load
+        when attribute?(name)   then attribute(name)
+        when predicate?(name)   then predicate(name)
+        when setter?(name)      then set_attribute(name, args.first)
+        else super
+        end
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        association?(name) || attribute?(name) || predicate?(name) || super
+      end
+
+      def association?(name)
+        associations.has_key?(name)
+      end
+
+      def association(name)
+        options = associations[name]
+        options[:type].new(self, name, options)
+      end
+
+      def attribute?(name)
+        attributes.has_key?(name)
+      end
+
+      def attribute(name)
+        attributes[name]
+      end
+
+      def predicate?(name)
+        name.to_s.end_with?('?')
+      end
+
+      def predicate(name)
+        !!attribute(depredicate(name))
+      end
+
+      def depredicate(name)
+        name.to_s.chomp('?').to_sym
+      end
+
+      def setter?(name)
+        name.to_s.end_with?('=')
+      end
+
+      def set_attribute(name, value)
+        attributes[name.to_s.chomp('=')] = value
+      end
+
+      def inspect_attributes
+        attributes.except(:id).map { |k, v| "#{k}: #{v.inspect}" }.join(' ')
+      end
+  end
+end

--- a/lib/spyke/attributes.rb
+++ b/lib/spyke/attributes.rb
@@ -1,126 +1,20 @@
-require 'spyke/collection'
-
 module Spyke
-  module Attributes
-    extend ActiveSupport::Concern
-
-    included do
-      attr_reader :attributes
-    end
-
-    module ClassMethods
-      def attributes(*args)
-        args.each do |attr|
-          define_method attr do
-            attribute(attr)
-          end
-        end
-      end
-    end
-
-    def initialize(attributes = {})
-      self.attributes = attributes
-      @uri_template = current_scope.uri
-    end
-
-    def attributes=(new_attributes)
-      @attributes ||= current_scope.params.with_indifferent_access
-      use_setters parse(new_attributes) if new_attributes
-    end
-
-    def id
-      attributes[:id]
-    end
-
-    def id=(value)
-      attributes[:id] = value if value.present?
-    end
-
-    def ==(other)
-      other.is_a?(Spyke::Base) && id == other.id
-    end
-
-    def inspect
-      "#<#{self.class}(#{uri}) id: #{id.inspect} #{inspect_attributes}>"
+  class Attributes < HashWithIndifferentAccess
+    def to_params
+      each_with_object({}) do |(key, value), parameters|
+        parameters[key] = parse_value(value)
+      end.with_indifferent_access
     end
 
     private
 
-      def parse(attributes)
-        attributes.each_with_object({}) do |(key, value), parameters|
-          parameters[key] = parse_value(value)
-        end
-      end
-
       def parse_value(value)
         case
-        when value.is_a?(Spyke::Base)         then parse(value.attributes)
-        when value.is_a?(Hash)                then parse(value)
+        when value.is_a?(Spyke::Base)         then value.attributes.to_params
         when value.is_a?(Array)               then value.map { |v| parse_value(v) }
         when value.respond_to?(:content_type) then Faraday::UploadIO.new(value.path, value.content_type)
         else value
         end
-      end
-
-      def use_setters(attributes)
-        attributes.each do |key, value|
-          send "#{key}=", value
-        end
-      end
-
-      def method_missing(name, *args, &block)
-        case
-        when association?(name) then association(name).load
-        when attribute?(name)   then attribute(name)
-        when predicate?(name)   then predicate(name)
-        when setter?(name)      then set_attribute(name, args.first)
-        else super
-        end
-      end
-
-      def respond_to_missing?(name, include_private = false)
-        association?(name) || attribute?(name) || predicate?(name) || super
-      end
-
-      def association?(name)
-        associations.has_key?(name)
-      end
-
-      def association(name)
-        options = associations[name]
-        options[:type].new(self, name, options)
-      end
-
-      def attribute?(name)
-        attributes.has_key?(name)
-      end
-
-      def attribute(name)
-        attributes[name]
-      end
-
-      def predicate?(name)
-        name.to_s.end_with?('?')
-      end
-
-      def predicate(name)
-        !!attribute(depredicate(name))
-      end
-
-      def depredicate(name)
-        name.to_s.chomp('?').to_sym
-      end
-
-      def setter?(name)
-        name.to_s.end_with?('=')
-      end
-
-      def set_attribute(name, value)
-        attributes[name.to_s.chomp('=')] = value
-      end
-
-      def inspect_attributes
-        attributes.except(:id).map { |k, v| "#{k}: #{v.inspect}" }.join(' ')
       end
   end
 end

--- a/lib/spyke/base.rb
+++ b/lib/spyke/base.rb
@@ -1,9 +1,10 @@
 require 'active_model'
 require 'spyke/associations'
-require 'spyke/attributes'
+require 'spyke/attribute_assignment'
 require 'spyke/orm'
 require 'spyke/http'
-require 'spyke/scopes'
+require 'spyke/scoping'
+
 
 module Spyke
   class Base
@@ -17,9 +18,9 @@ module Spyke
 
     # Spyke
     include Associations
-    include Attributes
+    include AttributeAssignment
     include Http
     include Orm
-    include Scopes
+    include Scoping
   end
 end

--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -8,9 +8,6 @@ module Spyke
     extend ActiveSupport::Concern
     METHODS = %i{ get post put patch delete }
 
-    included do
-    end
-
     module ClassMethods
       METHODS.each do |method|
         define_method(method) do |path, params = {}|

--- a/lib/spyke/orm.rb
+++ b/lib/spyke/orm.rb
@@ -50,9 +50,9 @@ module Spyke
 
     def to_params
       if include_root?
-        { self.class.model_name.param_key => attributes.except(*uri.variables) }
+        { self.class.model_name.param_key => attributes.to_params.except(*uri.variables)}
       else
-        attributes.except(*uri.variables)
+        attributes.to_params.except(*uri.variables)
       end
     end
 

--- a/lib/spyke/relation.rb
+++ b/lib/spyke/relation.rb
@@ -5,19 +5,17 @@ module Spyke
     include Enumerable
 
     attr_reader :klass, :params
+    attr_writer :params
     delegate :to_ary, :[], :empty?, :last, :size, :metadata, to: :find_some
 
     def initialize(klass, options = {})
       @klass, @options, @params = klass, options, {}
     end
 
-    def all
-      where
-    end
-
     def where(conditions = {})
-      @params.merge!(conditions)
-      self
+      relation = clone
+      relation.params = params.merge(conditions)
+      relation
     end
 
     # Overrides Enumerable find
@@ -53,10 +51,10 @@ module Spyke
 
       # Keep hold of current scope while running a method on the class
       def scoping
-        klass.current_scope = self
+        previous, klass.current_scope = klass.current_scope, self
         yield
       ensure
-        klass.current_scope = nil
+        klass.current_scope = previous
       end
   end
 end

--- a/lib/spyke/scoping.rb
+++ b/lib/spyke/scoping.rb
@@ -2,11 +2,15 @@ require 'spyke/relation'
 require 'spyke/scope_registry'
 
 module Spyke
-  module Scopes
+  module Scoping
     extend ActiveSupport::Concern
 
     module ClassMethods
-      delegate :all, :where, to: :current_scope
+      delegate :where, :build, to: :all
+
+      def all
+        current_scope || Relation.new(self, uri: uri)
+      end
 
       def scope(name, code)
         define_singleton_method name, code
@@ -17,14 +21,14 @@ module Spyke
       end
 
       def current_scope
-        ScopeRegistry.value_for(:current_scope, name) || Relation.new(self, uri: uri)
+        ScopeRegistry.value_for(:current_scope, name)
       end
     end
 
     private
 
-      def current_scope
-        self.class.current_scope
+      def scope
+        @scope ||= self.class.all
       end
   end
 end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -2,6 +2,12 @@ require 'test_helper'
 
 module Spyke
   class AttributesTest < MiniTest::Test
+
+    def test_basics
+      attr = Attributes.new(id: 3, 'title' => 'Fish', groups: [ Group.new(name: 'Starter'), { name: 'Dessert' } ])
+      assert_equal({ 'id' => 3 , 'title' => 'Fish', 'groups' => [{ 'name' => 'Starter' }, { 'name' => 'Dessert' }] }, attr.to_params)
+    end
+
     def test_predicate_methods
       stub_request(:get, 'http://sushi.com/recipes/1').to_return_json(result: { id: 1, title: 'Sushi' })
 


### PR DESCRIPTION
Previously building and changing Spyke associations after instantiation
would get ignored when calling to_params on the parent object. This
fixes that and brings Spyke closer to working like ActiveRecord.