### PR TITLE
Validate required params in path

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can specify custom URIs on both the class and association level:
 
 ```ruby
 class User < Spyke::Base
-  uri '/v1/users/:id'
+  uri '/v1/users/(:id)'
 
   has_one :image, uri: nil
   has_many :posts, uri: '/posts/for_user/:user_id'

--- a/lib/spyke/associations/has_many.rb
+++ b/lib/spyke/associations/has_many.rb
@@ -3,7 +3,7 @@ module Spyke
     class HasMany < Association
       def initialize(*args)
         super
-        @options.reverse_merge!(uri: "/#{parent.class.model_name.plural}/:#{foreign_key}/#{klass.model_name.plural}/:id")
+        @options.reverse_merge!(uri: "/#{parent.class.model_name.plural}/:#{foreign_key}/#{klass.model_name.plural}/(:id)")
         @params[foreign_key] = parent.id
       end
 

--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -50,7 +50,7 @@ module Spyke
         Collection.new Array(result.data).map { |record| new(record) }, result.metadata
       end
 
-      def uri(uri_template = "/#{model_name.plural}/:id")
+      def uri(uri_template = "/#{model_name.plural}/(:id)")
         @uri ||= uri_template
       end
 

--- a/lib/spyke/path.rb
+++ b/lib/spyke/path.rb
@@ -1,10 +1,12 @@
 require 'uri_template'
 
 module Spyke
+  class InvalidPathError < StandardError; end
   class Path
-    def initialize(uri_template, params = {})
-      @uri_template = URITemplate.new(:colon, uri_template)
-      @params = params
+
+    def initialize(pattern, params = {})
+      @pattern = pattern
+      @params = params.symbolize_keys
     end
 
     def join(other_path)
@@ -16,13 +18,36 @@ module Spyke
     end
 
     def variables
-      @variables ||= @uri_template.variables.map(&:to_sym)
+      @variables ||= uri_template.variables.map(&:to_sym)
     end
 
     private
 
+      def uri_template
+        @uri_template ||= URITemplate.new(:colon, pattern_with_rfc_style_parens)
+      end
+
+      def pattern_with_rfc_style_parens
+        @pattern.gsub('(', '{').gsub(')', '}')
+      end
+
       def path
-        @uri_template.expand(@params).chomp('/')
+        validate_required_params!
+        uri_template.expand(@params).chomp('/')
+      end
+
+      def validate_required_params!
+        if missing_required_params.any?
+          raise Spyke::InvalidPathError, "Missing required params: #{missing_required_params.join(', ')} in #{@pattern}. Mark optional params with parens eg: (:param)"
+        end
+      end
+
+      def missing_required_params
+        required_params - @params.keys
+      end
+
+      def required_params
+        @pattern.scan(/\/:(\w+)/).flatten.map(&:to_sym)
       end
   end
 end

--- a/test/path_test.rb
+++ b/test/path_test.rb
@@ -3,21 +3,27 @@ require 'test_helper'
 module Spyke
   class PathTest < MiniTest::Test
     def test_collection_path
-      assert_equal '/recipes', Path.new('/recipes/:id').to_s
+      assert_equal '/recipes', Path.new('/recipes/(:id)').to_s
     end
 
     def test_resource_path
-      assert_equal '/recipes/2', Path.new('/recipes/:id', id: 2).to_s
+      assert_equal '/recipes/2', Path.new('/recipes/(:id)', id: 2).to_s
     end
 
     def test_nested_collection_path
-      path = Path.new('/users/:user_id/recipes/:id', user_id: 1, status: 'published')
+      path = Path.new('/users/:user_id/recipes/(:id)', user_id: 1, status: 'published')
       assert_equal [:user_id, :id], path.variables
       assert_equal '/users/1/recipes', path.to_s
     end
 
     def test_nested_resource_path
       assert_equal '/users/1/recipes/2', Path.new('/users/:user_id/recipes/:id', user_id: 1, id: 2).to_s
+    end
+
+    def test_required_params
+      assert_raises Spyke::InvalidPathError, 'Missing required params: user_id in /users/:user_id/recipes/(:id)' do
+        Path.new('/users/:user_id/recipes/(:id)', id: 2).to_s
+      end
     end
   end
 end

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -59,7 +59,7 @@ class Group < Spyke::Base
 end
 
 class Ingredient < Spyke::Base
-  uri '/recipes/:recipe_id/ingredients/:id'
+  uri '/recipes/:recipe_id/ingredients/(:id)'
 end
 
 class User < Spyke::Base
@@ -67,7 +67,7 @@ class User < Spyke::Base
 end
 
 class Photo < Spyke::Base
-  uri '/images/photos/:id'
+  uri '/images/photos/(:id)'
 end
 
 class Comment < Spyke::Base
@@ -90,8 +90,8 @@ end
 
 module Cookbook
   class Tip < Spyke::Base
-    uri '/tips/:id'
-    has_many :likes, class_name: 'Cookbook::Like', uri: '/tips/:cookbook_tip_id/likes/:id'
+    uri '/tips/(:id)'
+    has_many :likes, class_name: 'Cookbook::Like', uri: '/tips/:cookbook_tip_id/likes/(:id)'
   end
 
   class Like < Spyke::Base


### PR DESCRIPTION
Before calling something like `User.new.posts` would send a request to
`/users/posts`, lacking the required user_id. This change raises an
exception when required parts of the path are missing and allows you to
specify "optional" params (such as `/users/(:id)`).