### PR TITLE
Adds customization root key on json params.

### DIFF
--- a/lib/spyke/orm.rb
+++ b/lib/spyke/orm.rb
@@ -49,7 +49,9 @@ module Spyke
     end
 
     def to_params
-      if include_root?
+      if include_root.is_a? String
+        { include_root => attributes.to_params.except(*uri.variables)}
+      elsif include_root?
         { self.class.model_name.param_key => attributes.to_params.except(*uri.variables)}
       else
         attributes.to_params.except(*uri.variables)

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -123,6 +123,11 @@ module Spyke
       assert_equal({ 'url' => 'bob.jpg' }, RecipeImage.new(url: 'bob.jpg').to_params)
     end
 
+    def test_non_nested_params_with_included_root
+      assert_equal({ 'step_image_root' => { 'url' => 'bob.jpg' } }, StepImage.new(url: 'bob.jpg').
+                                           to_params)
+    end
+
     def test_destroy
       endpoint = stub_request(:delete, 'http://sushi.com/recipes/1')
       Recipe.new(id: 1).destroy

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -37,12 +37,14 @@ class Image < Spyke::Base
 end
 
 class StepImage < Image
+  include_root_in_json "step_image_root"
 end
 
 class RecipeImage < Image
   uri '/recipes/:recipe_id/image'
   validates :url, presence: true
   attributes :url
+
   include_root_in_json false
 end
 


### PR DESCRIPTION
This adds a way to customize the root on json, passing a string on include_root_in_json method.