### PR TITLE
Introduce :use_i18n option to send plain text in errors hash

### DIFF
--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -80,10 +80,18 @@ module Spyke
       def add_errors_to_model(errors_hash)
         errors_hash.each do |field, field_errors|
           field_errors.each do |attributes|
-            error_name = attributes.delete(:error).to_sym
-            errors.add(field.to_sym, error_name, attributes.symbolize_keys)
+            message, options = extract_message(attributes)
+            errors.add(field.to_sym, message, options)
           end
         end
+      end
+
+      def extract_message(attributes)
+        use_i18n = attributes.reverse_merge(use_i18n: true).delete(:use_i18n)
+        error = attributes.delete(:error)
+        message = use_i18n ? error.to_sym : error
+
+        [message, attributes.symbolize_keys]
       end
 
       def resolve_path_from_action(action)

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -80,12 +80,12 @@ module Spyke
     end
 
     def test_create_with_server_returning_validation_errors
-      endpoint = stub_request(:put, 'http://sushi.com/recipes/1').to_return_json(id: 'write_error:400', errors: { title: [{ error: 'too_short', count: 4 }], groups: [{ error: 'blank' }] })
+      endpoint = stub_request(:put, 'http://sushi.com/recipes/1').to_return_json(id: 'write_error:400',
+        errors: { title: [{ error: :too_short, count: 4 }, { error: 'plain text', use_i18n: false }], groups: [{ error: 'blank' }] })
 
       recipe = Recipe.create(id: 1, title: 'sus')
-
       assert_equal 'sus', recipe.title
-      assert_equal ['Title is too short (minimum is 4 characters)', "Groups can't be blank"], recipe.errors.full_messages
+      assert_equal ['Title is too short (minimum is 4 characters)', 'Title plain text', "Groups can't be blank"], recipe.errors.full_messages
       assert_requested endpoint
     end
 


### PR DESCRIPTION
Before messages in the errors hash are expected to be used in I18n translation, with the format like `blank`, `invalid`, etc. This PR supports sending plain string message through the errors hash.