### PR TITLE
Allow uri to be inherited

### DIFF
--- a/lib/spyke/relation.rb
+++ b/lib/spyke/relation.rb
@@ -24,7 +24,7 @@ module Spyke
     end
 
     def find_one
-      @find_one ||= klass.new_from_result(fetch)
+      @find_one ||= klass.new_instance_from_result(fetch)
     end
 
     def find_some

--- a/lib/spyke/version.rb
+++ b/lib/spyke/version.rb
@@ -1,3 +1,3 @@
 module Spyke
-  VERSION = '1.8.3'
+  VERSION = '1.8.4'
 end

--- a/test/custom_request_test.rb
+++ b/test/custom_request_test.rb
@@ -19,7 +19,7 @@ module Spyke
     def test_get_request_with_appended_scope
       skip 'wishlisted'
       endpoint = stub_request(:get, 'http://sushi.com/recipes/recent?status=published')
-      Recipe.get('/recipes/recent').published.fetch
+      Recipe.get('/recipes/recent').published.to_a
       assert_requested endpoint
     end
 

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -113,9 +113,15 @@ module Spyke
       assert_requested endpoint
     end
 
-    def test_inheritance_using_custom_method
-      endpoint = stub_request(:put, 'http://sushi.com/step_images')
+    def test_inheritance_passes_on_custom_method_and_uri
+      endpoint = stub_request(:put, 'http://sushi.com/images')
       StepImage.create
+      assert_requested endpoint
+    end
+
+    def test_inheritance_not_overwriting_custom_uri
+      endpoint = stub_request(:put, 'http://sushi.com/recipes/1/image')
+      RecipeImage.where(recipe_id: 1).create
       assert_requested endpoint
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,3 +16,10 @@ Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }
 
 # Pretty colors
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
+
+# Don't raise but report uncaught net connections
+WebMock.allow_net_connect!
+WebMock.stub_request(:any, /.*/).to_return do |request|
+  puts "\e[35mUNSTUBBED REQUEST:\e[0m #{request.method.upcase} #{request.uri}"
+  { body: nil }
+end


### PR DESCRIPTION
Closes #18
Previously inheriting from other Spyke::Base classes would ignore the uri of those superclasses, ie:

```ruby
class Post < Spyke::Base
  uri "postings/(:id)"
end

class SpecialPost < Post
end

Post.find(1) # => GET /postings/1
SpecialPost.find(1) #=> GET /special_posts/1
```

This fixes it so that uri is inherited:

```ruby
Post.find(1) # => GET /postings/1
SpecialPost.find(1) #=> GET /postings/1
```