### PR TITLE
raise argument error for wrong number of params

### DIFF
--- a/lib/spyke/attribute_assignment.rb
+++ b/lib/spyke/attribute_assignment.rb
@@ -71,13 +71,12 @@ module Spyke
       end
 
       def method_missing(name, *args, &block)
-        case
-        when association?(name) then association(name).load
-        when attribute?(name)   then attribute(name)
-        when predicate?(name)   then predicate(name)
-        when setter?(name)      then set_attribute(name, args.first)
-        else super
-        end
+        return association(name).load  if association?(name) && args.length == 0
+        return attribute(name)         if attribute?(name)   && args.length == 0
+        return predicate(name)         if predicate?(name)   && args.length == 0
+        return set_attribute(name, args.first) if setter?(name) && args.length == 1
+        raise(ArgumentError) if (association?(name) || attribute?(name) || predicate?(name) || set_attribute(name, args.first))
+        super
       end
 
       def respond_to_missing?(name, include_private = false)

--- a/lib/spyke/attribute_assignment.rb
+++ b/lib/spyke/attribute_assignment.rb
@@ -75,7 +75,7 @@ module Spyke
         return attribute(name)         if attribute?(name)   && args.length == 0
         return predicate(name)         if predicate?(name)   && args.length == 0
         return set_attribute(name, args.first) if setter?(name) && args.length == 1
-        raise(ArgumentError) if (association?(name) || attribute?(name) || predicate?(name) || set_attribute(name, args.first))
+        raise(ArgumentError) if (association?(name) || attribute?(name) || predicate?(name) || setter?(name))
         super
       end
 

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -139,11 +139,11 @@ module Spyke
     end
 
     def test_rejecting_wrong_number_of_args
-      skip 'wishlisted'
       stub_request(:any, /.*/)
       recipe = Recipe.new(description: 'Delicious')
       assert_raises ArgumentError do
         recipe.description(2)
+        puts recipe.description(2)
       end
       assert_raises ArgumentError do
         recipe.description?(2)

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -143,7 +143,6 @@ module Spyke
       recipe = Recipe.new(description: 'Delicious')
       assert_raises ArgumentError do
         recipe.description(2)
-        puts recipe.description(2)
       end
       assert_raises ArgumentError do
         recipe.description?(2)


### PR DESCRIPTION
- rewrote method_missing to raise ArgumentError to reject wrong number of arguments
- changed the case statement to guard clauses