### PR TITLE
Allow to use uuids as ids

### DIFF
--- a/lib/spyke/orm.rb
+++ b/lib/spyke/orm.rb
@@ -42,9 +42,16 @@ module Spyke
         new(id: id).destroy
       end
 
-      def strip_slug(id)
-        id.to_s.split('-').first
-      end
+      private
+
+        def strip_slug(id)
+          id = id.to_s
+          is_uuid?(id) ? id : id.split('-').first
+        end
+  
+        def is_uuid?(string)
+          (/\A[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/i =~ string) != nil
+        end
     end
 
     def to_params

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -31,6 +31,12 @@ module Spyke
       assert_requested endpoint
     end
 
+    def test_find_with_uuid
+      endpoint = stub_request(:get, 'http://sushi.com/recipes/6EB3A9B6-4097-11E5-80EB-0357A0D4F70A').to_return_json(result: { id: '6EB3A9B6-4097-11E5-80EB-0357A0D4F70A' })
+      Recipe.find('6EB3A9B6-4097-11E5-80EB-0357A0D4F70A')
+      assert_requested endpoint
+    end
+
     def test_404
       stub_request(:get, 'http://sushi.com/recipes/1').to_return(status: 404, body: { message: 'Not found' }.to_json)
 


### PR DESCRIPTION
Fixes #48

  * strip_slug returns the id if this one has a uuid format
  * check naively the uuid format and do not take care of versions