### PR TITLE
Fix foreign keys being added to embed-only objects

### DIFF
--- a/lib/spyke/associations/association.rb
+++ b/lib/spyke/associations/association.rb
@@ -55,6 +55,10 @@ module Spyke
           parent.attributes[name]
         end
 
+        def embed_only?
+          @options[:uri].blank?
+        end
+
         def update_parent(value)
           parent.attributes[name] = value
         end

--- a/lib/spyke/associations/has_many.rb
+++ b/lib/spyke/associations/has_many.rb
@@ -4,7 +4,7 @@ module Spyke
       def initialize(*args)
         super
         @options.reverse_merge!(uri: "#{parent.class.model_name.element.pluralize}/:#{foreign_key}/#{@name}/(:id)")
-        @params[foreign_key] = parent.id
+        @params[foreign_key] = parent.id unless embed_only?
       end
 
       def load

--- a/lib/spyke/associations/has_one.rb
+++ b/lib/spyke/associations/has_one.rb
@@ -4,7 +4,7 @@ module Spyke
       def initialize(*args)
         super
         @options.reverse_merge!(uri: "#{parent.class.model_name.plural}/:#{foreign_key}/#{@name}")
-        @params[foreign_key] = parent.id
+        @params[foreign_key] = parent.id unless embed_only?
       end
     end
   end

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -183,8 +183,8 @@ module Spyke
       recipe.groups.first.ingredients.build(name: 'Salt')
 
       assert_equal %w{ Salt }, recipe.ingredients.map(&:name)
-      assert_equal({ 'recipe' => { 'groups' => [{ 'recipe_id' => 1, 'ingredients' => [{ 'group_id' => nil, 'name' => 'Salt' }] }] } }, recipe.to_params)
-      assert_equal({ 'group' => { 'ingredients' => [{ 'group_id' => nil, 'name' => 'Salt' }] } }, recipe.groups.first.to_params)
+      assert_equal({ 'recipe' => { 'groups' => [{ 'recipe_id' => 1, 'ingredients' => [{ 'name' => 'Salt' }] }] } }, recipe.to_params)
+      assert_equal({ 'group' => { 'ingredients' => [{ 'name' => 'Salt' }] } }, recipe.groups.first.to_params)
     end
 
     def test_deep_build_has_many_association_with_scope
@@ -363,16 +363,28 @@ module Spyke
       assert_equal 'photo.jpg', Recipe.new(background_image: { url: 'photo.jpg' }).background_image.url
     end
 
+    def test_build_with_embed_only_singular_associations
+      recipe = Recipe.new(id: 1)
+      recipe.build_background_image(caption: 'Stir')
+      assert_equal({ 'recipe' => { 'background_image' => { 'caption' => 'Stir' } } }, recipe.to_params)
+    end
+
     def test_embed_only_plural_associations
       assert_equal [], Group.new.ingredients.to_a
       assert_equal [1], Group.new(ingredients: [{ id: 1 }]).ingredients.map(&:id)
+    end
+
+    def test_build_with_embed_only_plural_associations
+      group = Group.new(id: 1)
+      group.ingredients.build(name: 'Salt')
+      assert_equal({ 'group' => { 'ingredients' => [{ 'name' => 'Salt' }] } }, group.to_params)
     end
 
     def test_class_methods_for_associations
       recipe = Recipe.new
       recipe.groups.build_default
 
-      assert_equal({ 'recipe' => { 'groups' => [{ 'recipe_id' => nil, 'name' => 'Condiments', 'ingredients' => [{ 'group_id' => nil, 'name' => 'Salt' }] }, { 'recipe_id' => nil, 'name' => 'Tools', 'ingredients' => [{ 'group_id' => nil, 'name' => 'Spoon' }] }] } }, recipe.to_params)
+      assert_equal({ 'recipe' => { 'groups' => [{ 'recipe_id' => nil, 'name' => 'Condiments', 'ingredients' => [{ 'name' => 'Salt' }] }, { 'recipe_id' => nil, 'name' => 'Tools', 'ingredients' => [{ 'name' => 'Spoon' }] }] } }, recipe.to_params)
       assert_equal %w{ Condiments Tools }, recipe.groups.map(&:name)
       assert_equal %w{ Salt Spoon }, recipe.ingredients.map(&:name)
     end


### PR DESCRIPTION
Fixes #58
Embedded associations that have no URI do not need to have the foreign key added when built through a parent.