### PR TITLE
Use a connection pool for faraday connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,32 @@ Spyke::Base.connection = Faraday.new(url: 'http://api.com') do |c|
 end
 ```
 
+You can also assign a connection pool instead of a plain connection with
+something like:
+
+```ruby
+# config/initializers/spyke.rb
+
+class JSONParser < Faraday::Response::Middleware
+  def parse(body)
+    json = MultiJson.load(body, symbolize_keys: true)
+    {
+      data: json[:result],
+      metadata: json[:extra],
+      errors: json[:errors]
+    }
+  end
+end
+
+Spyke::Base.connection_pool = ConnectionPool.new(size: 5, timeout: 5) do
+  Faraday.new(url: 'http://api.com') do |c|
+    c.request   :json
+    c.use       JSONParser
+    c.adapter   Faraday.default_adapter
+  end
+end
+```
+
 ## Usage
 
 Adding a class and inheriting from `Spyke::Base` will allow you to interact with the remote service:

--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -1,3 +1,4 @@
+require 'connection_pool'
 require 'faraday'
 require 'faraday_middleware'
 require 'spyke/config'

--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -20,18 +20,14 @@ module Spyke
         end
       end
 
-      def connection(&blk)
-        connection_pool.with(&blk)
-      end
-
       def connection=(connection)
         self.connection_pool = ConnectionPool.new(size: 1) { connection }
       end
 
       def request(method, path, params = {})
         ActiveSupport::Notifications.instrument('request.spyke', method: method) do |payload|
-          connection do |conn|
-            response = conn.send(method) do |request|
+          connection_pool.with do |connection|
+            response = connection.send(method) do |request|
               if method == :get
                 request.url path.to_s, params
               else

--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -10,7 +10,7 @@ module Spyke
     METHODS = %i{ get post put patch delete }
 
     included do
-      class_attribute :connection, instance_accessor: false
+      class_attribute :connection_pool, instance_accessor: false
     end
 
     module ClassMethods
@@ -20,18 +20,28 @@ module Spyke
         end
       end
 
+      def connection(&blk)
+        connection_pool.with(&blk)
+      end
+
+      def connection=(connection)
+        self.connection_pool = ConnectionPool.new(size: 1) { connection }
+      end
+
       def request(method, path, params = {})
         ActiveSupport::Notifications.instrument('request.spyke', method: method) do |payload|
-          response = connection.send(method) do |request|
-            if method == :get
-              request.url path.to_s, params
-            else
-              request.url path.to_s
-              request.body = params
+          connection do |conn|
+            response = conn.send(method) do |request|
+              if method == :get
+                request.url path.to_s, params
+              else
+                request.url path.to_s
+                request.body = params
+              end
             end
+            payload[:url], payload[:status] = response.env.url, response.status
+            Result.new_from_response(response)
           end
-          payload[:url], payload[:status] = response.env.url, response.status
-          Result.new_from_response(response)
         end
       end
 

--- a/spyke.gemspec
+++ b/spyke.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '>= 0.9.0', '< 2.0'
   spec.add_dependency 'faraday_middleware', '>= 0.9.1', '< 2.0'
   spec.add_dependency 'uri_template', '>= 0.7.0', '< 2.0'
+  spec.add_dependency 'connection_pool', '>= 2.2.0', '< 2.3.0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'coveralls', '~> 0.7'

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -155,14 +155,14 @@ module Spyke
     end
 
     def test_relative_uris
-      previous = Spyke::Base.connection.url_prefix
-      Spyke::Base.connection.url_prefix = 'http://sushi.com/api/v2/'
+      previous = Spyke::TestConnection.url_prefix
+      Spyke::TestConnection.url_prefix = 'http://sushi.com/api/v2/'
 
       endpoint = stub_request(:get, 'http://sushi.com/api/v2/recipes')
       Recipe.all.to_a
       assert_requested endpoint
 
-      Spyke::Base.connection.url_prefix = previous
+      Spyke::TestConnection.url_prefix = previous
     end
   end
 end

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -12,11 +12,13 @@ class JSONParser < Faraday::Response::Middleware
   end
 end
 
-Spyke::Base.connection = Faraday.new(url: 'http://sushi.com') do |faraday|
+Spyke::TestConnection = Faraday.new(url: 'http://sushi.com') do |faraday|
   faraday.request   :json
   faraday.use       JSONParser
   faraday.adapter   Faraday.default_adapter
 end
+
+Spyke::Base.connection = Spyke::TestConnection
 
 # Test classes
 class Recipe < Spyke::Base


### PR DESCRIPTION
Uses a connection pool around faraday clients instead of assuming the faraday connection is shareable arbitrarily across threads (it most likely isn't).

If a connection is assigned directly, this gets wrapped in a connection pool with a size of 1. Otherwise, the connection pool will be created as part of the client setup.
