### PR TITLE
Support Ruby 1.9 Enumerators with Associations

### DIFF
--- a/lib/spyke/relation.rb
+++ b/lib/spyke/relation.rb
@@ -40,8 +40,8 @@ module Spyke
       @find_some ||= klass.new_collection_from_result(fetch)
     end
 
-    def each
-      find_some.each { |record| yield record }
+    def each(&blk)
+      find_some.each(&blk)
     end
 
     def uri

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -15,7 +15,7 @@ module Spyke
       assert_kind_of Enumerator, Recipe.new(id: 1).groups.each
     end
 
-    def test_association_get_
+    def test_association_get_ingredients_with_index
       group = Group.new(ingredients: [Ingredient.new(name: 'Water'), Ingredient.new(name: 'Flour')])
       expected_ingredients_with_index = [['Water', 0], ['Flour', 1]]
       actual_ingredients_with_index = group.ingredients.each.with_index.map {|ingredient, idx| [ingredient.name, idx]}

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -9,6 +9,12 @@ module Spyke
       end
     end
 
+    def test_association_each_returns_enumerator
+      stub_request(:get, 'http://sushi.com/recipes/1').to_return_json(result: { groups: [{ id: 1, name: 'Fish' }] })
+
+      assert_kind_of Enumerator, Recipe.new(id: 1).groups.each
+    end
+
     def test_initializing_with_has_many_association
       group = Group.new(ingredients: [Ingredient.new(name: 'Water'), Ingredient.new(name: 'Flour')])
       assert_equal %w{ Water Flour }, group.ingredients.map(&:name)

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -15,6 +15,14 @@ module Spyke
       assert_kind_of Enumerator, Recipe.new(id: 1).groups.each
     end
 
+    def test_association_get_
+      group = Group.new(ingredients: [Ingredient.new(name: 'Water'), Ingredient.new(name: 'Flour')])
+      expected_ingredients_with_index = [['Water', 0], ['Flour', 1]]
+      actual_ingredients_with_index = group.ingredients.each.with_index.map {|ingredient, idx| [ingredient.name, idx]}
+
+      assert_equal expected_ingredients_with_index, actual_ingredients_with_index
+    end
+
     def test_initializing_with_has_many_association
       group = Group.new(ingredients: [Ingredient.new(name: 'Water'), Ingredient.new(name: 'Flour')])
       assert_equal %w{ Water Flour }, group.ingredients.map(&:name)


### PR DESCRIPTION
Providing a .each that calls yield directly means that a large part of the Ruby 1.9 enumerator API isn't directly usable, such as chaining calls (e.g. .each.with_index.with_object.map). This is currently possible with Spyke associations by explicitly calling .to_a prior to doing any enumerator chaining.

By passing the block on instead, we can 'piggy-back' off Array#each correctly implementing Enumerator support in the situation where no block is passed. This allows full access to the enumerator API directly, rather than with an explicit .to_a call first.