### PR TITLE
Adds support for resource identifier other than :id

### DIFF
--- a/lib/spyke/associations/belongs_to.rb
+++ b/lib/spyke/associations/belongs_to.rb
@@ -3,8 +3,8 @@ module Spyke
     class BelongsTo < Association
       def initialize(*args)
         super
-        @options.reverse_merge!(uri: "#{@name.to_s.pluralize}/:#{id_key}", foreign_key: "#{klass.model_name.element}_id")
-        @params[id_key] = parent.try(foreign_key)
+        @options.reverse_merge!(uri: "#{@name.to_s.pluralize}/:#{primary_key}", foreign_key: "#{klass.model_name.element}_id")
+        @params[primary_key] = parent.try(foreign_key)
       end
     end
   end

--- a/lib/spyke/associations/belongs_to.rb
+++ b/lib/spyke/associations/belongs_to.rb
@@ -3,8 +3,8 @@ module Spyke
     class BelongsTo < Association
       def initialize(*args)
         super
-        @options.reverse_merge!(uri: "#{@name.to_s.pluralize}/:id", foreign_key: "#{klass.model_name.element}_id")
-        @params[:id] = parent.try(foreign_key)
+        @options.reverse_merge!(uri: "#{@name.to_s.pluralize}/:#{id_key}", foreign_key: "#{klass.model_name.element}_id")
+        @params[id_key] = parent.try(foreign_key)
       end
     end
   end

--- a/lib/spyke/associations/has_many.rb
+++ b/lib/spyke/associations/has_many.rb
@@ -3,7 +3,8 @@ module Spyke
     class HasMany < Association
       def initialize(*args)
         super
-        @options.reverse_merge!(uri: "#{parent.class.model_name.element.pluralize}/:#{foreign_key}/#{@name}/(:#{id_key})")
+        parent_path = parent.class.model_name.element.pluralize
+        @options.reverse_merge!(uri: "#{parent_path}/:#{foreign_key}/#{@name}/(:#{primary_key})")
         @params[foreign_key] = parent.id
       end
 
@@ -35,11 +36,11 @@ module Spyke
         end
 
         def group_by_primary_key(array)
-          array.group_by { |h| h.with_indifferent_access[id_key].to_s }
+          array.group_by { |h| h.with_indifferent_access[primary_key].to_s }
         end
 
         def primary_keys_present_in_existing?
-          embedded_attributes && embedded_attributes.any? { |attr| attr.has_key?(id_key) }
+          embedded_attributes && embedded_attributes.any? { |attr| attr.has_key?(primary_key) }
         end
 
         def clear_existing!

--- a/lib/spyke/associations/has_many.rb
+++ b/lib/spyke/associations/has_many.rb
@@ -3,7 +3,7 @@ module Spyke
     class HasMany < Association
       def initialize(*args)
         super
-        @options.reverse_merge!(uri: "#{parent.class.model_name.element.pluralize}/:#{foreign_key}/#{@name}/(:id)")
+        @options.reverse_merge!(uri: "#{parent.class.model_name.element.pluralize}/:#{foreign_key}/#{@name}/(:#{id_key})")
         @params[foreign_key] = parent.id
       end
 
@@ -35,11 +35,11 @@ module Spyke
         end
 
         def group_by_primary_key(array)
-          array.group_by { |h| h.with_indifferent_access[:id].to_s }
+          array.group_by { |h| h.with_indifferent_access[id_key].to_s }
         end
 
         def primary_keys_present_in_existing?
-          embedded_attributes && embedded_attributes.any? { |attr| attr.has_key?('id') }
+          embedded_attributes && embedded_attributes.any? { |attr| attr.has_key?(id_key) }
         end
 
         def clear_existing!

--- a/lib/spyke/attribute_assignment.rb
+++ b/lib/spyke/attribute_assignment.rb
@@ -69,9 +69,28 @@ module Spyke
     private
 
       def use_setters(attributes)
+        # NOTE: special treatment for :id key, a resource can be identified by
+        # :id or by user defined id_key (default is :id) but in the case where
+        # both id_key and ':id' are passed, :id is treated as attribute
+        # independent of id_key and  primary_key will be id_key
+        # user can acess the data in :id using resource[:id]
+
+        if conflicting_ids?(attributes)
+          id_key = self.class.id_key
+          @attributes[:id] = attributes.delete(:id)
+          @attributes[id_key] = attributes.delete(id_key)
+        end
+
         attributes.each do |key, value|
           send "#{key}=", value
         end
+      end
+
+      def conflicting_ids?(attributes)
+        id_key = self.class.id_key
+        id_key != :id &&
+          attributes.key?(:id) &&
+          attributes.key?(id_key)
       end
 
       def method_missing(name, *args, &block)

--- a/lib/spyke/attribute_assignment.rb
+++ b/lib/spyke/attribute_assignment.rb
@@ -42,11 +42,11 @@ module Spyke
     end
 
     def id
-      attributes[:id]
+      attributes[self.class.id_key]
     end
 
     def id=(value)
-      attributes[:id] = value if value.present?
+      attributes[self.class.id_key] = value if value.present?
     end
 
     def hash
@@ -125,7 +125,7 @@ module Spyke
       end
 
       def inspect_attributes
-        attributes.except(:id).map { |k, v| "#{k}: #{v.inspect}" }.join(' ')
+        attributes.except(self.class.id_key).map { |k, v| "#{k}: #{v.inspect}" }.join(' ')
       end
   end
 end

--- a/lib/spyke/attribute_assignment.rb
+++ b/lib/spyke/attribute_assignment.rb
@@ -42,11 +42,11 @@ module Spyke
     end
 
     def id
-      attributes[self.class.id_key]
+      attributes[self.class.primary_key]
     end
 
     def id=(value)
-      attributes[self.class.id_key] = value if value.present?
+      attributes[self.class.primary_key] = value if value.present?
     end
 
     def hash
@@ -70,15 +70,15 @@ module Spyke
 
       def use_setters(attributes)
         # NOTE: special treatment for :id key, a resource can be identified by
-        # :id or by user defined id_key (default is :id) but in the case where
-        # both id_key and ':id' are passed, :id is treated as attribute
-        # independent of id_key and  primary_key will be id_key
+        # :id or by user defined primary_key (default is :id) but in the case where
+        # both primary_key and ':id' are passed, :id is treated as attribute
+        # independent of primary_key and  primary_key will be primary_key
         # user can acess the data in :id using resource[:id]
 
         if conflicting_ids?(attributes)
-          id_key = self.class.id_key
+          primary_key = self.class.primary_key
           @attributes[:id] = attributes.delete(:id)
-          @attributes[id_key] = attributes.delete(id_key)
+          @attributes[primary_key] = attributes.delete(primary_key)
         end
 
         attributes.each do |key, value|
@@ -87,10 +87,10 @@ module Spyke
       end
 
       def conflicting_ids?(attributes)
-        id_key = self.class.id_key
-        id_key != :id &&
+        primary_key = self.class.primary_key
+        primary_key != :id &&
           attributes.key?(:id) &&
-          attributes.key?(id_key)
+          attributes.key?(primary_key)
       end
 
       def method_missing(name, *args, &block)
@@ -144,7 +144,7 @@ module Spyke
       end
 
       def inspect_attributes
-        attributes.except(self.class.id_key).map { |k, v| "#{k}: #{v.inspect}" }.join(' ')
+        attributes.except(self.class.primary_key).map { |k, v| "#{k}: #{v.inspect}" }.join(' ')
       end
   end
 end

--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -72,7 +72,7 @@ module Spyke
         end
 
         def default_uri
-          "#{model_name.element.pluralize}/(:#{id_key})"
+          "#{model_name.element.pluralize}/(:#{primary_key})"
         end
     end
 

--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -72,7 +72,7 @@ module Spyke
         end
 
         def default_uri
-          "#{model_name.element.pluralize}/(:id)"
+          "#{model_name.element.pluralize}/(:#{id_key})"
         end
     end
 

--- a/lib/spyke/orm.rb
+++ b/lib/spyke/orm.rb
@@ -17,9 +17,9 @@ module Spyke
         self.include_root = value
       end
 
-      attr_writer :id_key
-      def id_key
-        @id_key ||= :id
+      attr_writer :primary_key
+      def primary_key
+        @primary_key ||= :id
       end
 
       def method_for(callback, value = nil)
@@ -29,7 +29,7 @@ module Spyke
 
       def find(id)
         raise ResourceNotFound if id.blank?
-        where(id_key => id).find_one || raise(ResourceNotFound)
+        where(primary_key => id).find_one || raise(ResourceNotFound)
       end
 
       def fetch
@@ -43,7 +43,7 @@ module Spyke
       end
 
       def destroy(id = nil)
-        new(id_key => id).destroy
+        new(primary_key => id).destroy
       end
     end
 

--- a/lib/spyke/orm.rb
+++ b/lib/spyke/orm.rb
@@ -17,6 +17,11 @@ module Spyke
         self.include_root = value
       end
 
+      attr_writer :id_key
+      def id_key
+        @id_key ||= :id
+      end
+
       def method_for(callback, value = nil)
         self.callback_methods = callback_methods.merge(callback => value) if value
         callback_methods[callback]
@@ -24,7 +29,7 @@ module Spyke
 
       def find(id)
         raise ResourceNotFound if id.blank?
-        where(id: id).find_one || raise(ResourceNotFound)
+        where(id_key => id).find_one || raise(ResourceNotFound)
       end
 
       def fetch
@@ -38,7 +43,7 @@ module Spyke
       end
 
       def destroy(id = nil)
-        new(id: id).destroy
+        new(id_key => id).destroy
       end
     end
 

--- a/lib/spyke/orm.rb
+++ b/lib/spyke/orm.rb
@@ -17,9 +17,8 @@ module Spyke
         self.include_root = value
       end
 
-      attr_writer :primary_key
-      def primary_key
-        @primary_key ||= :id
+      def primary_key(value = nil)
+        @primary_key ||= value || :id
       end
 
       def method_for(callback, value = nil)

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -307,14 +307,14 @@ module Spyke
       assert_equal %w{ flavor }, recipe.groups.map(&:title)
     end
 
-    def test_nested_attributes_merging_with_existing_when_ids_present?
+    def test_nested_attributes_merging_with_existing_when_ids_present
       recipe = Recipe.new(groups_attributes: [{ id: 1, title: 'starter', description: 'nice' }, { id: 2, title: 'sauce', description: 'spicy' }])
       recipe.attributes = { groups_attributes: [{ 'id' => '2', 'title' => 'flavor' }, { 'title' => 'spices', 'description' => 'lovely' }, { 'title' => 'sweetener', 'description' => 'sweet' }] }
       assert_equal %w{ starter flavor spices sweetener }, recipe.groups.map(&:title)
       assert_equal %w{ nice spicy lovely sweet }, recipe.groups.map(&:description)
     end
 
-    def test_nested_attributes_appending_to_existing_when_ids_present?
+    def test_nested_attributes_appending_to_existing_when_ids_present
       recipe = Recipe.new(groups_attributes: [{ id: 1, title: 'starter' }, { id: 2, title: 'sauce' }])
       recipe.attributes = { groups_attributes: [{ title: 'flavor' }] }
       assert_equal %w{ starter sauce flavor }, recipe.groups.map(&:title)
@@ -427,6 +427,27 @@ module Spyke
       assert_raises NameError do
         Cookbook::Tip.new.votes
       end
+    end
+
+    def test_custom_primary_key_for_belongs_to
+      comment_endpoint = stub_request(:get, 'http://sushi.com/comments/1').to_return_json(result: { user_id: 1 })
+      user_endpoint = stub_request(:get, 'http://sushi.com/users/1').to_return_json(result: { user_id: 1 })
+      comment = Comment.find(1)
+      assert_equal 1, comment.user.id
+      assert_requested comment_endpoint
+      assert_requested user_endpoint
+    end
+
+    def test_custom_primary_key_for_has_many
+      stub_request(:get, 'http://sushi.com/comments/1').to_return_json(result: { users: [{ user_id: 1 }] })
+      comment = Comment.find(1)
+      assert_equal 1, comment.users.first.id
+    end
+
+    def test_custom_primary_key_with_nested_attributes
+      comment = Comment.new(users_attributes: [{ id: 1, name: "user_1" }])
+      comment.attributes = { users_attributes: [{ id: 1, name: "user_1_new_name"}] }
+      assert_equal %w{ user_1_new_name}, comment.users.map(&:name)
     end
   end
 end

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -439,14 +439,15 @@ module Spyke
     end
 
     def test_custom_primary_key_for_has_many
-      stub_request(:get, 'http://sushi.com/comments/1').to_return_json(result: { users: [{ user_id: 1 }] })
+      stub_request(:get, 'http://sushi.com/comments/1').to_return_json(result: { users: [{ id: 1 }] })
       comment = Comment.find(1)
       assert_equal 1, comment.users.first.id
     end
 
     def test_custom_primary_key_with_nested_attributes
-      comment = Comment.new(users_attributes: [{ id: 1, name: "user_1" }])
-      comment.attributes = { users_attributes: [{ id: 1, name: "user_1_new_name"}] }
+      comment = Comment.new(users_attributes: [{ user_id: 1, name: "user_1" }])
+#      binding.pry
+      comment.attributes = { users_attributes: [{ user_id: 1, name: "user_1_new_name"}] }
       assert_equal %w{ user_1_new_name}, comment.users.map(&:name)
     end
   end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -139,7 +139,7 @@ module Spyke
       recipe = Recipe.new
       assert_equal '#<Recipe(recipes/(:id)) id: nil >', recipe.inspect
       user = Recipe.new.build_user
-      assert_equal '#<User(users/:id) id: nil >', user.inspect
+      assert_equal '#<User(users/:user_id) id: nil >', user.inspect
       group = Recipe.new.groups.build
       assert_equal '#<Group(recipes/:recipe_id/groups/(:id)) id: nil recipe_id: nil>', group.inspect
     end

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -168,5 +168,9 @@ module Spyke
 
       Spyke::Base.connection.url_prefix = previous
     end
+
+    def test_custom_id_key
+      assert_equal 'users/(:user_id)', User.uri
+    end
   end
 end

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -169,8 +169,11 @@ module Spyke
       Spyke::Base.connection.url_prefix = previous
     end
 
-    def test_custom_id_key
-      assert_equal 'users/(:user_id)', User.uri
+    def test_custom_primary_key_on_find
+      endpoint = stub_request(:get, 'http://sushi.com/users').to_return_json(result: [{ user_id: 1 }])
+      users = User.all.to_a
+      assert_requested endpoint
+      assert_equal 1, users.first.id
     end
   end
 end

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -174,6 +174,26 @@ module Spyke
       users = User.all.to_a
       assert_requested endpoint
       assert_equal 1, users.first.id
+      assert_equal 1, users.first.user_id
+    end
+
+    def test_custom_primary_key_and_id_are_the_same
+      endpoint = stub_request(:get, 'http://sushi.com/users').to_return_json(result: [{ user_id: 1 }])
+      user = User.all.to_a.first
+      assert_requested endpoint
+      assert_equal 1, user.id
+      assert_equal user.user_id, user.id
+    end
+
+    def test_custom_primary_key_but_has_id_attribute
+      endpoint = stub_request(:get, 'http://sushi.com/users').to_return_json(result: [{ user_id: 1, id: 42 }])
+      user = User.all.to_a.first
+      assert_requested endpoint
+
+      assert_equal 1, user.id
+      assert_equal user.id, user.user_id
+      assert_equal 1, user[User.id_key]
+      assert_equal 42, user[:id]
     end
   end
 end

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -192,7 +192,7 @@ module Spyke
 
       assert_equal 1, user.id
       assert_equal user.id, user.user_id
-      assert_equal 1, user[User.id_key]
+      assert_equal 1, user[User.primary_key]
       assert_equal 42, user[:id]
     end
   end

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -103,7 +103,10 @@ class Photo < Spyke::Base
 end
 
 class Comment < Spyke::Base
+  belongs_to :user
+  has_many :users
   scope :approved, -> { where(comment_approved: true) }
+  accepts_nested_attributes_for :users
 end
 
 class OtherApi < Spyke::Base

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -94,7 +94,7 @@ class Ingredient < Spyke::Base
 end
 
 class User < Spyke::Base
-  self.primary_key = :user_id
+  primary_key :user_id
   has_many :recipes
 end
 

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -94,6 +94,7 @@ class Ingredient < Spyke::Base
 end
 
 class User < Spyke::Base
+  self.id_key = :user_id
   has_many :recipes
 end
 

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -94,7 +94,7 @@ class Ingredient < Spyke::Base
 end
 
 class User < Spyke::Base
-  self.id_key = :user_id
+  self.primary_key = :user_id
   has_many :recipes
 end
 


### PR DESCRIPTION
Previously all Spyke resources must be identified by :id, which
makes it hard to create a generic response middleware that can
handle different identifier per resource.

This patch allows resource identifier to be declared using `id_key`
class method and defaults to :id

Ref: https://github.com/balvig/spyke/issues/69