### PR TITLE
Allow defaults in subclass

### DIFF
--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -50,7 +50,7 @@ module Spyke
       private
 
         def scoped_request(method)
-          uri = new.uri
+          uri = new(current_scope.params).uri
           params = current_scope.params.except(*uri.variables)
           request(method, uri, params)
         end

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -5,13 +5,16 @@ module Spyke
     def test_find
       stub_request(:get, 'http://sushi.com/recipes/1').to_return_json(result: { id: 1, title: 'Sushi' })
       stub_request(:get, 'http://sushi.com/users/1').to_return_json(result: { id: 1, name: 'Bob' })
+      stub_request(:get, 'http://sushi.com/books/978-3').to_return_json(result: { isbn: "978-3", title: 'Recipe Book'})
 
       recipe = Recipe.find(1)
       user = User.find(1)
+      book = Book.find("978-3")
 
       assert_equal 1, recipe.id
       assert_equal 'Sushi', recipe.title
       assert_equal 'Bob', user.name
+      assert_equal 'Recipe Book', book.title
     end
 
     def test_reload

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -86,6 +86,14 @@ module Spyke
       assert_requested endpoint
     end
 
+    def test_create_with_defaults
+      endpoint = stub_request(:post, 'http://sushi.com/book_with_defaults').with(body: { book_with_defaults: { isbn: '123', title: 'Best of Sushi' } }).to_return_json(result: { id: 1, title: 'Best of Sushi', isbn: '123' })
+
+      book = BookWithDefault.create(title: 'Best of Sushi')
+
+      assert_requested endpoint
+    end
+
     def test_create_with_server_returning_validation_errors
       endpoint = stub_request(:put, 'http://sushi.com/recipes/1').to_return_json(id: 'write_error:400', errors: { title: [{ error: 'too_short', count: 4 }], groups: [{ error: 'blank' }] })
 

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -98,6 +98,15 @@ class User < Spyke::Base
   has_many :recipes
 end
 
+class Book < Spyke::Base
+  self.primary_key = :isbn
+
+  def initialize(attributes = {})
+    defaults = {isbn: nil}.with_indifferent_access
+    super(defaults.merge(attributes || {}))
+  end
+end
+
 class Photo < Spyke::Base
   uri 'images/photos/(:id)'
 end

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -107,6 +107,14 @@ class Book < Spyke::Base
   end
 end
 
+class BookWithDefault < Spyke::Base
+  attributes :isbn, :title
+
+  def isbn
+    attributes[:isbn] || "123"
+  end
+end
+
 class Photo < Spyke::Base
   uri 'images/photos/(:id)'
 end


### PR DESCRIPTION
If one subclasses a `Spyke::Base` and sets defaults in `initialize`, then spyke is not able to build the correct request path, because it calls `new` without any arguments. This then creates an object with only the defaults, which can't be used to build a correct request path
