### PR TITLE
Add support for rescuing gracefully from connection failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,24 @@ remap it in Faraday to match the above. Doing this will allow you to
 show errors returned from the server in forms and f.ex using
 `@post.errors.full_messages` just like ActiveRecord.
 
+### Error handling and fallbacks
+
+Should the API fail to connect or time out, a `Spyke::ConnectionError` will be raised.
+If you need to recover gracefully from connection problems, you can
+either rescue that exception or use the `with_fallback` feature:
+
+```ruby
+# API is down
+Article.all # => Spyke::ConnectionError
+Article.with_fallback.all # => []
+
+Article.find(1) # => Spyke::ConnectionError
+Article.with_fallback.find(1) # => nil
+
+article = Article.with_fallback(Article.new(title: "Dummy")).find(1)
+article.title # => "Dummy"
+```
+
 ### Attributes-wrapping
 
 Spyke, like Rails, by default wraps sent attributes in a root element,

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   ruby:
-    version: 2.1.5
+    version: 2.2.2

--- a/lib/spyke/exceptions.rb
+++ b/lib/spyke/exceptions.rb
@@ -1,3 +1,4 @@
 module Spyke
   class ResourceNotFound < StandardError; end
+  class ConnectionError < StandardError; end
 end

--- a/lib/spyke/scoping.rb
+++ b/lib/spyke/scoping.rb
@@ -7,7 +7,7 @@ module Spyke
 
     module ClassMethods
       delegate :where, :build, :any?, :empty?, to: :all
-      delegate :with, to: :all
+      delegate :with, :with_fallback, to: :all
 
       def all
         current_scope || Relation.new(self, uri: uri)

--- a/test/fallbacks_test.rb
+++ b/test/fallbacks_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+module Spyke
+  class FallbacksTest < MiniTest::Test
+    def setup
+      stub_request(:get, "http://sushi.com/recipes/1").to_timeout
+      stub_request(:get, "http://sushi.com/recipes?published=true").to_timeout
+    end
+
+    def test_find_with_default_fallback
+      assert_raises ResourceNotFound do
+        Recipe.with_fallback.find(1)
+      end
+    end
+
+    def test_find_with_custom_fallback
+      dummy_recipe = Recipe.new(title: "Dummy Recipe")
+
+      result = Recipe.with_fallback(dummy_recipe).find(1)
+
+      assert_equal "Dummy Recipe", result.title
+    end
+
+    def test_find_one_with_default_fallback
+      recipe = Recipe.with_fallback.where(id: 1).find_one
+
+      assert_equal nil, recipe
+    end
+
+    def test_find_some_with_default_fallback
+      assert_equal [], Recipe.where(published: true).with_fallback.all.to_a
+    end
+
+    def test_find_some_with_custom_fallback
+      dummy_result = [Recipe.new(title: "Dummy Recipe")]
+
+      result = Recipe.where(published: true).with_fallback(dummy_result).all
+
+      assert_equal "Dummy Recipe", result.first.title
+    end
+  end
+end


### PR DESCRIPTION
Should the API fail to connect or time out, a `Spyke::ConnectionError` will be raised.
If you need to recover gracefully from connection problems, you can
either rescue that exception or use the `with_fallback` feature:

```ruby
# API is down
Article.all # => Spyke::ConnectionError
Article.with_fallback.all # => []

Article.find(1) # => Spyke::ConnectionError
Article.with_fallback.find(1) # => nil

article = Article.with_fallback(Article.new(title: "Dummy")).find(1)
article.title # => "Dummy"
```