### PR TITLE
Fix typo in ivar check

### DIFF
--- a/lib/spyke/attribute_assignment.rb
+++ b/lib/spyke/attribute_assignment.rb
@@ -15,7 +15,7 @@ module Spyke
       # they become overridable with "super".
       # http://thepugautomatic.com/2013/07/dsom/
       def attributes(*names)
-        unless instance_variable_defined?(:@spyke_instance_method_containear)
+        unless instance_variable_defined?(:@spyke_instance_method_container)
           @spyke_instance_method_container = Module.new
           include @spyke_instance_method_container
         end


### PR DESCRIPTION
Sadly, I added a typo when I fixed this warning.

Hi again,

I was just thinking through some other changes to this project and I noticed that my last change introduced a typo and consequently a performance regression. Doh! 

Here's the fix. I tripled checked it this time 😅

Thanks again for this project and your time. 