### PR TITLE
use setters for attributes to make setting faster

### DIFF
--- a/lib/spyke/attribute_assignment.rb
+++ b/lib/spyke/attribute_assignment.rb
@@ -25,6 +25,10 @@ module Spyke
             define_method(name) do
               attribute(name)
             end
+
+            define_method(:"#{name}=") do |value|
+              set_attribute(name, value)
+            end
           end
         end
       end


### PR DESCRIPTION
Hi,

I was reading through the library and I noticed that it does not materialize setters for the known attributes. The usage of method missing works perfectly fine, but it's not the most performant. This patch includes a change that defines setters for known attributes the same way that we're already defining getters. Notably, this patch doesn't define methods for "dynamic attributes" -- the ones that are not included in the call to `.attributes`.

I ran a benchmark which shows that adding the setter methods is **2x faster** on Ruby 2.3.1 when setting an attribute. Here's the script:

```ruby
require 'spyke'
require 'benchmark/ips'

class Widget < Spyke::Base
  attributes :foo
end

widget = Widget.new

Benchmark.ips do |x|
  x.report("setter with method") do
    widget.foo = "bar"
  end

  x.report("setter without method") do
    widget.baz = "bat"
  end

  x.compare!
end

Benchmark.ips do |x|
  x.report("initializer with method") do
    Widget.new(foo: 'bar')
  end

  x.report("initalizer without method") do
    Widget.new(baz: 'bat')
  end

  x.compare!
end
```

**Results**
```
$ ruby -Ilib bench.rb
Warming up --------------------------------------
  setter with method    64.441k i/100ms
setter without method
                        31.695k i/100ms
Calculating -------------------------------------
  setter with method    747.970k (± 1.9%) i/s -      3.802M in   5.084949s
setter without method
                        355.156k (± 2.3%) i/s -      1.775M in   5.000272s

Comparison:
  setter with method:   747969.8 i/s
setter without method:   355155.7 i/s - 2.11x  slower

Warming up --------------------------------------
initializer with method
                        14.343k i/100ms
initalizer without method
                        11.097k i/100ms
Calculating -------------------------------------
initializer with method
                        150.919k (± 3.5%) i/s -    760.179k in   5.043508s
initalizer without method
                        118.700k (± 2.4%) i/s -    599.238k in   5.051255s

Comparison:
initializer with method:   150919.4 i/s
initalizer without method:   118699.5 i/s - 1.27x  slower
```

What do you think?

Other thoughts:
* I think we probably want to extend this behavior to include predicate methods and associations. What do you think?
* I'm curious how you feel about [`ActiveModel::AttributeMethods`](http://api.rubyonrails.org/classes/ActiveModel/AttributeMethods.html). I am wondering if it would be worth investigating migrating the `AttributeAssignment` mixin to use that approach.
