### PR TITLE
Tackling issue #10 and supporting APIs with extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,40 +153,6 @@ Post.request(:post, 'posts/3/log', time: '12:00')
 # => POST http://api.com/posts/3/log - { time: '12:00' }
 ```
 
-### Working with XML
-
-Spyke also handles APIs, which return XML data:
-
-```ruby
-class XMLParser < Faraday::Response::Middleware
-    def parse(body)
-        xml = YourFavoriteXMLLibrary.parse(body)
-        {
-            data: xml[:result],
-            metadata: xml[:extra],
-            errors: xml[:errors]
-        }
-  end
-end
-
-Spyke::Base.connection = Faraday.new(url: 'http://xmlapi.com') do |c|
-    c.headers['Content-Type'] = 'application/xml'
-    c.use       XMLParser
-    c.adapter   Faraday.default_adapter
-end
-```
-
-To connect to API URLs with .xml extensions you will need to setup a custom URI:
-
-```ruby
-class Project < Spyke::Base
-    uri 'projects(/:id).xml'
-end
-
-Project.all # => GET http://xmlapi.com/projects.xml
-Project.find(6) # => GET http://xmlapi.com/projects/6.xml
-```
-
 ### API-side validations
 
 Spyke expects errors to be formatted in the same way as the

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ user = User.find(3)
 # => GET http://api.com/users/3
 
 user.posts
-# => find embedded in returned JSON or GET http://api.com/users/3/posts
+# => find embedded in returned data or GET http://api.com/users/3/posts
 
 user.update(name: 'Alice')
 # => PUT http://api.com/users/3 - { user: { name: 'Alice' } }
@@ -106,22 +106,22 @@ User.create(name: 'Bob')
 ### Custom URIs
 
 You can specify custom URIs on both the class and association level.
-Set uri to `nil` for associations you only want to use embedded JSON
-and never call out to the API.
+Set uri to `nil` for associations you only want to use data embedded
+in the response and never call out to the API.
 
 ```ruby
 class User < Spyke::Base
-  uri 'people/(:id)' # id optional, both /people and /people/4 are valid
+  uri 'people(/:id)' # id optional, both /people and /people/4 are valid
 
   has_many :posts, uri: 'posts/for_user/:user_id' # user_id is required
-  has_one :image, uri: nil # only use embedded JSON
+  has_one :image, uri: nil # only use embedded data
 end
 
 class Post < Spyke::Base
 end
 
 user = User.find(3) # => GET http://api.com/people/3
-user.image # Will only use embedded JSON and never call out to api
+user.image # Will only use embedded data and never call out to api
 user.posts # => GET http://api.com/posts/for_user/3
 Post.find(4) # => GET http://api.com/posts/4
 ```

--- a/README.md
+++ b/README.md
@@ -153,6 +153,40 @@ Post.request(:post, 'posts/3/log', time: '12:00')
 # => POST http://api.com/posts/3/log - { time: '12:00' }
 ```
 
+### Working with XML
+
+Spyke also handles APIs, which return XML data:
+
+```
+class XMLParser < Faraday::Response::Middleware
+    def parse(body)
+        xml = YourFavoriteXMLLibrary.parse(body)
+        {
+            data: xml[:result],
+            metadata: xml[:extra],
+            errors: xml[:errors]
+        }
+  end
+end
+
+Spyke::Base.connection = Faraday.new(url: 'http://xmlapi.com') do |c|
+    c.headers['Content-Type'] = 'application/xml'
+    c.use       XMLParser
+    c.adapter   Faraday.default_adapter
+end
+```
+
+To connect to API URLs with .xml extensions you will need to setup a custom URI:
+
+```
+class Project < Spyke::Base
+    uri 'projects(/:id).xml'
+end
+
+Project.all # => GET http://xmlapi.com/projects.xml
+Project.find(6) # => GET http://xmlapi.com/projects/6.xml
+```
+
 ### API-side validations
 
 Spyke expects errors to be formatted in the same way as the

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Post.request(:post, 'posts/3/log', time: '12:00')
 
 Spyke also handles APIs, which return XML data:
 
-```
+```ruby
 class XMLParser < Faraday::Response::Middleware
     def parse(body)
         xml = YourFavoriteXMLLibrary.parse(body)
@@ -178,7 +178,7 @@ end
 
 To connect to API URLs with .xml extensions you will need to setup a custom URI:
 
-```
+```ruby
 class Project < Spyke::Base
     uri 'projects(/:id).xml'
 end

--- a/lib/spyke/path.rb
+++ b/lib/spyke/path.rb
@@ -1,4 +1,5 @@
 require 'addressable/template'
+require 'spyke/rfc_converter'
 
 module Spyke
   class InvalidPathError < StandardError; end
@@ -27,11 +28,7 @@ module Spyke
       end
 
       def pattern_with_rfc_style_parens
-        # to be compatible with colon style:
-        # Step 1: replace all :var inside parentheses (optional vars) with {:var}
-        # Step 2: replace all parentheses with curly braces
-        # Step 3: remove all colons
-        @pattern.gsub(/(:\w+(?!\)))\b/, '{\1}').gsub('(', '{').gsub(')', '}').gsub(':', '')
+        RfcConverter.new(@pattern).convert
       end
 
       def path

--- a/lib/spyke/path.rb
+++ b/lib/spyke/path.rb
@@ -3,7 +3,6 @@ require 'addressable/template'
 module Spyke
   class InvalidPathError < StandardError; end
   class Path
-
     def initialize(pattern, params = {})
       @pattern = pattern
       @params = params.symbolize_keys
@@ -36,30 +35,32 @@ module Spyke
       end
 
       def path
-        validate_required_params!
+        validate_required_variables!
         uri_template.expand(@params).to_s.chomp('/')
       end
 
-      def validate_required_params!
-        if missing_required_params.any?
-          raise Spyke::InvalidPathError, "Missing required params: #{missing_required_params.join(', ')} in #{@pattern}. Mark optional params with parens eg: (:param)"
+      def validate_required_variables!
+        if missing_required_variables.any?
+          raise Spyke::InvalidPathError, "Missing required variables: #{missing_required_variables.join(', ')} in #{@pattern}. Mark optional variables with parens eg: (:param)"
         end
       end
 
-      def missing_required_params
-        required_params - params_with_values
+      def missing_required_variables
+        required_variables - variables_with_values
       end
 
-      def params_with_values
+      def variables_with_values
         @params.map do |key, value|
           key if value.present?
         end.compact
       end
 
-      def required_params
-        allp = @pattern.scan(/:(\w+)/).flatten.map(&:to_sym)
-        optp = @pattern.scan(/\(\/?:(\w+)\)/).flatten.map(&:to_sym)
-        allp - optp
+      def required_variables
+        variables - optional_variables
+      end
+
+      def optional_variables
+        @pattern.scan(/\(\/?:(\w+)\)/).flatten.map(&:to_sym)
       end
   end
 end

--- a/lib/spyke/rfc_converter.rb
+++ b/lib/spyke/rfc_converter.rb
@@ -1,0 +1,33 @@
+module Spyke
+  class RfcConverter
+    def initialize(input)
+      @input = input
+    end
+
+    def convert
+      output = @input.dup
+      output = wrap_required_variables_in_curly_braces(output)
+      output = convert_start_parens_curly_braces(output)
+      output = convert_end_parens_to_curly_braces(output)
+      output = remove_colons(output)
+      output
+    end
+
+    private
+      def wrap_required_variables_in_curly_braces(text)
+        text.gsub(/(:\w+(?!\)))\b/, '{\1}')
+      end
+
+      def convert_start_parens_curly_braces(text)
+        text.gsub('(', '{')
+      end
+
+      def convert_end_parens_to_curly_braces(text)
+        text.gsub(')', '}')
+      end
+
+      def remove_colons(text)
+        text.gsub(':', '')
+      end
+  end
+end

--- a/lib/spyke/rfc_converter.rb
+++ b/lib/spyke/rfc_converter.rb
@@ -7,8 +7,7 @@ module Spyke
     def convert
       output = @input.dup
       output = wrap_required_variables_in_curly_braces(output)
-      output = convert_start_parens_curly_braces(output)
-      output = convert_end_parens_to_curly_braces(output)
+      output = convert_parens_to_curly_braces(output)
       output = remove_colons(output)
       output
     end
@@ -18,12 +17,8 @@ module Spyke
         text.gsub(/(:\w+(?!\)))\b/, '{\1}')
       end
 
-      def convert_start_parens_curly_braces(text)
-        text.gsub('(', '{')
-      end
-
-      def convert_end_parens_to_curly_braces(text)
-        text.gsub(')', '}')
+      def convert_parens_to_curly_braces(text)
+        text.gsub('(', '{').gsub(')', '}')
       end
 
       def remove_colons(text)

--- a/spyke.gemspec
+++ b/spyke.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activemodel', '>= 4.0.0', '< 6.0'
   spec.add_dependency 'faraday', '>= 0.9.0', '< 2.0'
   spec.add_dependency 'faraday_middleware', '>= 0.9.1', '< 2.0'
-  spec.add_dependency 'uri_template', '>= 0.7.0', '< 2.0'
+  spec.add_dependency 'addressable', '>= 2.5.2'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'coveralls', '~> 0.7'

--- a/test/path_test.rb
+++ b/test/path_test.rb
@@ -24,12 +24,16 @@ module Spyke
       assert_raises Spyke::InvalidPathError, 'Missing required params: user_id in /users/:user_id/recipes/(:id)' do
         Path.new('/users/:user_id/recipes/(:id)', id: 2).to_s
       end
+      assert_raises Spyke::InvalidPathError, 'Missing required params: part2, part4' do
+        Path.new('/1/profiles(/:part1)/:part2(/:part3)/:part4.xml').to_s
+      end
     end
 
     def test_optional_params_with_extension
-      skip 'wishlisted'
       assert_equal '/1/profiles/2.json', Path.new('/1/profiles(/:id).json', id: 2).to_s
       assert_equal '/1/profiles.json', Path.new('/1/profiles(/:id).json').to_s
+      assert_equal '/1/profiles.xml', Path.new('/1/profiles(/:id1)(/:id2)(/:id3)(/:id4).xml').to_s
+      assert_equal '/1/profiles/other/2.xml', Path.new('/1/profiles(/:part1)/:part2(/:part3)/:id.xml', part2: 'other', id: 2).to_s
     end
   end
 end

--- a/test/path_test.rb
+++ b/test/path_test.rb
@@ -20,14 +20,14 @@ module Spyke
       assert_equal '/users/1/recipes/2', Path.new('/users/:user_id/recipes/:id', user_id: 1, id: 2).to_s
     end
 
-    def test_required_params
-      assert_raises Spyke::InvalidPathError, 'Missing required params: user_id in /users/:user_id/recipes/(:id)' do
+    def test_required_variables
+      assert_raises Spyke::InvalidPathError, 'Missing required variables: user_id in /users/:user_id/recipes/(:id)' do
         Path.new('/users/:user_id/recipes/(:id)', id: 2).to_s
       end
     end
 
-    def test_mix_of_required_and_unrequired_params
-      assert_raises Spyke::InvalidPathError, 'Missing required params: part2, part4' do
+    def test_mix_of_required_and_unrequired_variables
+      assert_raises Spyke::InvalidPathError, 'Missing required variables: part2, part4' do
         Path.new('/1/profiles(/:part1)/:part2(/:part3)/:part4.xml').to_s
       end
     end
@@ -36,15 +36,15 @@ module Spyke
       assert_equal '/1/profiles/2.json', Path.new('/1/profiles(/:id).json', id: 2).to_s
     end
 
-    def test_missing_optional_params_with_extension
+    def test_missing_optional_variables_with_extension
       assert_equal '/1/profiles.json', Path.new('/1/profiles(/:id).json').to_s
     end
 
-    def test_multiple_missing_optional_params_with_extension
+    def test_multiple_missing_optional_variables_with_extension
       assert_equal '/1/profiles.xml', Path.new('/1/profiles(/:id1)(/:id2)(/:id3)(/:id4).xml').to_s
     end
 
-    def test_mixture_of_optional_params_and_required_params_with_extension
+    def test_mixture_of_optional_variables_and_required_variables_with_extension
       assert_equal '/1/profiles/other/2.xml', Path.new('/1/profiles(/:part1)/:part2(/:part3)/:id.xml', part2: 'other', id: 2).to_s
     end
   end

--- a/test/path_test.rb
+++ b/test/path_test.rb
@@ -24,15 +24,27 @@ module Spyke
       assert_raises Spyke::InvalidPathError, 'Missing required params: user_id in /users/:user_id/recipes/(:id)' do
         Path.new('/users/:user_id/recipes/(:id)', id: 2).to_s
       end
+    end
+
+    def test_mix_of_required_and_unrequired_params
       assert_raises Spyke::InvalidPathError, 'Missing required params: part2, part4' do
         Path.new('/1/profiles(/:part1)/:part2(/:part3)/:part4.xml').to_s
       end
     end
 
-    def test_optional_params_with_extension
+    def test_present_optional_param_with_extension
       assert_equal '/1/profiles/2.json', Path.new('/1/profiles(/:id).json', id: 2).to_s
+    end
+
+    def test_missing_optional_params_with_extension
       assert_equal '/1/profiles.json', Path.new('/1/profiles(/:id).json').to_s
+    end
+
+    def test_multiple_missing_optional_params_with_extension
       assert_equal '/1/profiles.xml', Path.new('/1/profiles(/:id1)(/:id2)(/:id3)(/:id4).xml').to_s
+    end
+
+    def test_mixture_of_optional_params_and_required_params_with_extension
       assert_equal '/1/profiles/other/2.xml', Path.new('/1/profiles(/:part1)/:part2(/:part3)/:id.xml', part2: 'other', id: 2).to_s
     end
   end


### PR DESCRIPTION
This is my suggested change to support #10 

- switched from uri_template to addressable
- compatible with uri_template colon format (although I am not entirely happy with the gsub regex, maybe someone finds a better/shorter regex for converting to addressable RFC)
- all tests are passing, added some more for Path
- added some (hopefully) helpful information and code fragments for working with XML APIs to the README