### PR TITLE
Support plain string validation errors

### DIFF
--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -3,6 +3,7 @@ require 'faraday_middleware'
 require 'spyke/config'
 require 'spyke/path'
 require 'spyke/result'
+require 'spyke/normalized_validation_error'
 
 module Spyke
   module Http
@@ -102,15 +103,9 @@ module Spyke
 
       def add_errors_to_model(errors_hash)
         errors_hash.each do |field, field_errors|
-          field_errors.each do |field_error|
-            if field_error.is_a? String
-              error_name = field_error
-              error_attrs = {}
-            else
-              error_name = field_error.delete(:error).to_sym
-              error_attrs = field_error.symbolize_keys
-            end
-            errors.add(field.to_sym, error_name, error_attrs)
+          field_errors.each do |error_attributes|
+            error = NormalizedValidationError.new(error_attributes)
+            errors.add(field.to_sym, error.message, error.options)
           end
         end
       end

--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -102,9 +102,15 @@ module Spyke
 
       def add_errors_to_model(errors_hash)
         errors_hash.each do |field, field_errors|
-          field_errors.each do |attributes|
-            error_name = attributes.delete(:error).to_sym
-            errors.add(field.to_sym, error_name, attributes.symbolize_keys)
+          field_errors.each do |field_error|
+            if field_error.is_a? String
+              error_name = field_error
+              error_attrs = {}
+            else
+              error_name = field_error.delete(:error).to_sym
+              error_attrs = field_error.symbolize_keys
+            end
+            errors.add(field.to_sym, error_name, error_attrs)
           end
         end
       end

--- a/lib/spyke/normalized_validation_error.rb
+++ b/lib/spyke/normalized_validation_error.rb
@@ -1,0 +1,27 @@
+module Spyke
+  class NormalizedValidationError
+    ERROR_KEY = :error
+
+    def initialize(attributes)
+      @attributes = attributes
+    end
+
+    def message
+      case @attributes
+      when String
+        @attributes
+      when Hash
+        @attributes[ERROR_KEY].to_sym
+      end
+    end
+
+    def options
+      case @attributes
+      when String
+        {}
+      when Hash
+        @attributes.except(ERROR_KEY).symbolize_keys
+      end
+    end
+  end
+end

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -93,6 +93,16 @@ module Spyke
       assert_requested endpoint
     end
 
+    def test_create_with_server_returning_string_validation_errors
+      endpoint = stub_request(:put, 'http://sushi.com/recipes/1').to_return_json(id: 'write_error:400', errors: { title: ["is too short"], groups: ["can't be blank"] })
+
+      recipe = Recipe.create(id: 1, title: 'sus')
+
+      assert_equal 'sus', recipe.title
+      assert_equal ['Title is too short', "Groups can't be blank"], recipe.errors.full_messages
+      assert_requested endpoint
+    end
+
     def test_find_using_custom_uri_template
       endpoint = stub_request(:get, 'http://sushi.com/images/photos/1').to_return_json(result: { id: 1 })
       Photo.find(1)


### PR DESCRIPTION
Currently, Spyke only supports a strict error format where the errors are translated on the client (Spyke's) side.  Some APIs return errors that already have been translated and this has not go through ActiveModel's error translation.

This commit add supports for plain string messages in the format:

```json
  { "errors":
    { "base": [ "Not saved (HTTP 422)" ],
      "some_attribute": [ "can't be blank", "is too short" ] } }
```

Without this patch, Spyke puts a high demand on the APIs.  Also, even if a Faraday middleware can be employed to get the errors hash in the right format, it would be weird for it to map translated strings to symbols so that ActiveModel can translate them back again.