### PR TITLE
Logical error for response processing

### DIFF
--- a/lib/spyke/result.rb
+++ b/lib/spyke/result.rb
@@ -7,7 +7,7 @@ module Spyke
     end
 
     def initialize(body)
-      @body = HashWithIndifferentAccess.new(body)
+      @body = body.respond_to?(:to_hash) ? HashWithIndifferentAccess.new(body) : HashWithIndifferentAccess.new({})
     end
 
     def data


### PR DESCRIPTION
My case:
Result return "" for #errors when DELETE method responded with no body(204 status).

Problem
HashWithIndifferentAccess.new pass first argument to Hash.new that recognize it as default value for all keys. This happen when body don't repond to #to_hash