### PR TITLE
Add test coverage for the deprecated connection setup.

### DIFF
--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+module Spyke
+  class ConfigConnectionWarnTest < MiniTest::Test
+
+    def test_config_connection_warn
+      assert_output '', "[DEPRECATION] `Spyke::Config.connection=` is deprecated.  Please use `Spyke::Base.connection=` instead.\n" do
+        Spyke::Config.connection = Spyke::Base.connection
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ensure it raises the deprecation warning when setting the connection though the old method.