### PR TITLE
Use primary key for `#persisted?`

### DIFF
--- a/lib/spyke/attribute_assignment.rb
+++ b/lib/spyke/attribute_assignment.rb
@@ -45,6 +45,10 @@ module Spyke
       use_setters(new_attributes) if new_attributes
     end
 
+    def id?
+      id.present?
+    end
+
     def id
       attributes[primary_key]
     end

--- a/lib/spyke/orm.rb
+++ b/lib/spyke/orm.rb
@@ -54,7 +54,7 @@ module Spyke
     end
 
     def persisted?
-      send("#{self.class.primary_key}?")
+      id?
     end
 
     def save

--- a/lib/spyke/orm.rb
+++ b/lib/spyke/orm.rb
@@ -54,7 +54,7 @@ module Spyke
     end
 
     def persisted?
-      id?
+      send("#{self.class.primary_key}?")
     end
 
     def save

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -209,10 +209,10 @@ module Spyke
 
     def test_custom_primary_key_used_for_persistence_check
       user = User.new
-      assert_equal false, user.persisted?
+      refute user.persisted?
 
       user.uuid = 1
-      assert_equal true, user.persisted?
+      assert user.persisted?
     end
   end
 end

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -206,5 +206,13 @@ module Spyke
       assert_equal 1, user[:uuid]
       assert_equal 42, user[:id]
     end
+
+    def test_custom_primary_key_used_for_persistence_check
+      user = User.new
+      assert_equal false, user.persisted?
+
+      user.uuid = 1
+      assert_equal true, user.persisted?
+    end
   end
 end


### PR DESCRIPTION
I think the test explains it all, but I'd expect `#persisted?` to be based on the presence of whatever argument I defined as the primary key.

Not sure about the best way to write it though, I didn't want to write `!!primary_key` to avoid duplicating the logic of the predicate methods, but the way I did it now might be kind of convoluted so I'm open to suggestions