### PR TITLE
Use @spyke_attributes instead of @attributes instance var

### DIFF
--- a/lib/spyke/attribute_assignment.rb
+++ b/lib/spyke/attribute_assignment.rb
@@ -6,7 +6,6 @@ module Spyke
     extend ActiveSupport::Concern
 
     included do
-      attr_reader :attributes
       delegate :[], :[]=, to: :attributes
     end
 
@@ -40,8 +39,12 @@ module Spyke
       yield self if block_given?
     end
 
+    def attributes
+      @spyke_attributes
+    end
+
     def attributes=(new_attributes)
-      @attributes ||= Attributes.new(scope.params)
+      @spyke_attributes ||= Attributes.new(scope.params)
       use_setters(new_attributes) if new_attributes
     end
 


### PR DESCRIPTION
I recently tried to integrate `ActiveModel::Dirty` into my Spyke models, and was met with this problem:

> As of v5.2.0 `ActiveModel::Dirty` checks to see if `ActiveRecord` attributes exist, assuming that if the instance variable `@attributes` exists on the instance, it is because they are `ActiveRecord` attributes.

Her solved this the same way: https://github.com/remiprev/her/commit/a4817537c32d838c8656197f177c6660be83e11c