### PR TITLE
Add custom primary key to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ Post.request(:post, 'posts/3/log', time: '12:00')
 # => POST http://api.com/posts/3/log - { time: '12:00' }
 ```
 
+### Custom primary keys
+
+Custom primary keys can be defined with `self.primary_key = :custom_key`:
+
+```ruby
+class User < Spyke::Base
+  self.primary_key = :user_id
+  
+  # When using custom URIs the :id parameter also has to be adjusted
+  uri 'people(/:user_id)'
+end
+```
+
 ### API-side validations
 
 Spyke expects errors to be formatted in the same way as the


### PR DESCRIPTION
This PR only add a section about how to define a custom primary key to the documentation

There is already an example in [fixtures.rb](https://github.com/balvig/spyke/blob/master/test/support/fixtures.rb#L97), but it's hard to find.

It looks like this:
### Custom primary keys

Custom primary keys can be defined with `self.primary_key = :custom_key`:

```ruby
class User < Spyke::Base
  self.primary_key = :user_id
  
  # When using custom URIs the :id parameter also has to be adjusted
  uri 'people(/:user_id)'
end
```