### PR TITLE
Make sure if the incoming nested attributes for a has_many associatio…

### DIFF
--- a/lib/spyke/associations/has_many.rb
+++ b/lib/spyke/associations/has_many.rb
@@ -12,6 +12,13 @@ module Spyke
       end
 
       def assign_nested_attributes(incoming)
+        # This ensures that if we are in a verison of Rails where params are
+        # an instance of ActionController::Params instad of Hash, we convert
+        # the params to a Hash.  Note that if the ActionController::Params
+        # instance is not permitted (strong params), an error is raised on .to_h
+        if incoming.respond_to?(:permitted?)
+          incoming = incoming.to_h
+        end
         incoming = incoming.values if incoming.is_a?(Hash)
         combined_attributes = combine_with_existing(incoming)
         clear_existing!

--- a/lib/spyke/version.rb
+++ b/lib/spyke/version.rb
@@ -1,3 +1,3 @@
 module Spyke
-  VERSION = '5.3.4'
+  VERSION = '5.3.5'
 end


### PR DESCRIPTION
…n are an ActionController:Params instance, we convert to hash first.  Fixes #111

The code block I'm adding is [taken straight from ActiveRecord](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/nested_attributes.rb#L465) so the behavior should mirror AR models.