### PR TITLE
Convert ActionController::Parameters to Hash when assigning attributes

### DIFF
--- a/lib/spyke/associations/has_many.rb
+++ b/lib/spyke/associations/has_many.rb
@@ -12,6 +12,13 @@ module Spyke
       end
 
       def assign_nested_attributes(incoming)
+        # This ensures that if we are in a verison of Rails where params are
+        # an instance of ActionController::Params instad of Hash, we convert
+        # the params to a Hash.  Note that if the ActionController::Params
+        # instance is not permitted (strong params), an error is raised on .to_h
+        if incoming.respond_to?(:permitted?)
+          incoming = incoming.to_h
+        end
         incoming = incoming.values if incoming.is_a?(Hash)
         combined_attributes = combine_with_existing(incoming)
         clear_existing!

--- a/lib/spyke/associations/has_many.rb
+++ b/lib/spyke/associations/has_many.rb
@@ -12,13 +12,11 @@ module Spyke
       end
 
       def assign_nested_attributes(incoming)
-        # This ensures that if we are in a verison of Rails where params are
-        # an instance of ActionController::Params instad of Hash, we convert
-        # the params to a Hash.  Note that if the ActionController::Params
-        # instance is not permitted (strong params), an error is raised on .to_h
+        # Convert attributes to a hash in case they are sent as ActionController::Parameters
         if incoming.respond_to?(:permitted?)
           incoming = incoming.to_h
         end
+
         incoming = incoming.values if incoming.is_a?(Hash)
         combined_attributes = combine_with_existing(incoming)
         clear_existing!

--- a/lib/spyke/attribute_assignment.rb
+++ b/lib/spyke/attribute_assignment.rb
@@ -45,6 +45,14 @@ module Spyke
 
     def attributes=(new_attributes)
       @spyke_attributes ||= Attributes.new(scope.params)
+
+      # Convert attributes to a hash in case they are sent as ActionController::Parameters
+      # Note: this is where Rails would raise its ForbiddenAttributesError if any are unpermitted
+      # https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activemodel/lib/active_model/forbidden_attributes_protection.rb#L21-L28
+      if new_attributes.respond_to?(:permitted?)
+        new_attributes = new_attributes.to_h
+      end
+
       use_setters(new_attributes) if new_attributes
     end
 

--- a/lib/spyke/version.rb
+++ b/lib/spyke/version.rb
@@ -1,3 +1,3 @@
 module Spyke
-  VERSION = '5.3.4'
+  VERSION = '5.3.5'
 end

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -301,13 +301,24 @@ module Spyke
       assert_equal 'Bob', recipe.user.name
     end
 
+    def test_nested_attributes_has_many
+      recipe = Recipe.new(groups_attributes: [{ title: 'starter' }, { title: 'sauce' }])
+      assert_equal %w{ starter sauce }, recipe.groups.map(&:title)
+    end
+
+    def test_nested_attributes_has_one_using_strong_params
+      recipe = Recipe.new(image_attributes: ProtectedParams.new(file: 'bob.jpg').permit!)
+      assert_equal 'bob.jpg', recipe.image.file
+    end
+
     def test_nested_attributes_belongs_to_using_strong_params
-      recipe = Recipe.new(ProtectedParams.new(user_attributes: { name: 'Bob' }).permit!)
+      recipe = Recipe.new(user_attributes: ProtectedParams.new({ name: 'Bob' }).permit!)
       assert_equal 'Bob', recipe.user.name
     end
 
-    def test_nested_attributes_has_many
-      recipe = Recipe.new(groups_attributes: [{ title: 'starter' }, { title: 'sauce' }])
+    def test_nested_attributes_has_many_using_strong_params
+      params = ProtectedParams.new(groups_attributes: [ProtectedParams.new(title: 'starter').permit!, ProtectedParams.new(title: 'sauce').permit!]).permit!
+      recipe = Recipe.new(params)
       assert_equal %w{ starter sauce }, recipe.groups.map(&:title)
     end
 
@@ -332,12 +343,6 @@ module Spyke
 
     def test_nested_attributes_has_many_using_hash_syntax
       recipe = Recipe.new(groups_attributes: { '0' => { title: 'starter' }, '1' => { title: 'sauce' } })
-      assert_equal %w{ starter sauce }, recipe.groups.map(&:title)
-    end
-
-    def test_nested_attributes_has_many_using_strong_params_with_array_syntax
-      params = ProtectedParams.new(groups_attributes: [ProtectedParams.new(title: 'starter').permit!, ProtectedParams.new(title: 'sauce').permit!]).permit!
-      recipe = Recipe.new(params)
       assert_equal %w{ starter sauce }, recipe.groups.map(&:title)
     end
 

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -159,3 +159,30 @@ class RecipeWithDirty < Recipe
   # for testing compatibility.
   include ActiveModel::Dirty
 end
+
+# Strong Parameters stub copied from Rails
+# https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activerecord/test/support/stubs/strong_parameters.rb
+class ProtectedParams
+  delegate :keys, :key?, :has_key?, :empty?, :to_h, :[], to: :@parameters
+
+  def initialize(parameters = {})
+    @parameters = parameters.with_indifferent_access
+    @permitted = false
+  end
+
+  def permitted?
+    @permitted
+  end
+
+  def permit!
+    @permitted = true
+    self
+  end
+
+  def dup
+    super.tap do |duplicate|
+      duplicate.instance_variable_set :@permitted, @permitted
+    end
+  end
+  alias stringify_keys dup
+end


### PR DESCRIPTION
This is a fork / continuation of the work done here: https://github.com/balvig/spyke/pull/112

Fixes #111

#### `AttributeAssignment#attribute=`
When ActiveRecord mass-assigns attributes, it first sanitizes them and can raise an error, which is not something Spyke does. https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activemodel/lib/active_model/attribute_assignment.rb#L28-L36

However, during that sanitization, it checks for `ActionController::Parameters`, checks if they are permitted, and then converts to a hash. So that's why I added the conversion in `AttributeAssignment#attributes=` in this PR.
https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activemodel/lib/active_model/forbidden_attributes_protection.rb#L21-L28 

#### `HasMany#assign_nested_attributes`
However for `has_many` nested attributes, these do not appear to be handled via the above method. Looks like Rails also converts to a hash again here when dealing with nested collections:
https://github.com/twalpole/rails/blob/b5d4dd47deaae27e8f362bb9636246c5b4c56e5c/activerecord/lib/active_record/nested_attributes.rb#L448-L450

#### Tests
I mostly copied Rails' test coverage here, save for the raised error for unpermitted params. 
https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activerecord/test/cases/forbidden_attributes_protection_test.rb#L112-L130

If you'd like to add an (optional) `ForbiddenAttributesError` raise to Spyke, this PR should lay a lot of the groundwork for that!

**Edit:** p.s. I'm not sure how you feel about including comments referencing Rails' internals and specific git URLs, but I felt it was important to point out the parallels and why some decisions were made. I'm happy to remove them and just include them in commit messages and/or this PR instead.