### PR TITLE
Make send_request method public

### DIFF
--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -41,20 +41,20 @@ module Spyke
         @uri ||= uri_template || default_uri
       end
 
-      private
-
-        def send_request(method, path, params)
-          connection.send(method) do |request|
-            if method == :get
-              request.url path.to_s, params
-            else
-              request.url path.to_s
-              request.body = params
-            end
+      def send_request(method, path, params)
+        connection.send(method) do |request|
+          if method == :get
+            request.url path.to_s, params
+          else
+            request.url path.to_s
+            request.body = params
           end
-          rescue Faraday::ConnectionFailed, Faraday::TimeoutError
-            raise ConnectionError
         end
+        rescue Faraday::ConnectionFailed, Faraday::TimeoutError
+          raise ConnectionError
+      end
+
+      private
 
         def scoped_request(method)
           uri = new.uri

--- a/test/custom_request_test.rb
+++ b/test/custom_request_test.rb
@@ -63,9 +63,16 @@ module Spyke
     end
 
     def test_multiple_apis
-      endpoint = stub_request(:get, 'http://sashimi.com/other_recipes')
+      endpoint = stub_request(:get, 'http://sashimi.com/recipes')
       OtherRecipe.all.to_a
       assert_requested endpoint
+    end
+
+    def test_multiple_apis_with_custom_fallback
+      fallback_endpoint = stub_request(:get, 'http://sushi.com/recipes')
+      primary_endpoint = stub_request(:get, 'http://sashimi.com/recipes').to_timeout
+      OtherRecipe.all.to_a
+      assert_requested fallback_endpoint
     end
   end
 end

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -116,7 +116,15 @@ class OtherApi < Spyke::Base
   end
 end
 
-class OtherRecipe < OtherApi; end
+class OtherRecipe < OtherApi
+  uri 'recipes/(:id)'
+
+  def self.send_request(method, path, params)
+    super
+  rescue Spyke::ConnectionError
+    Recipe.send_request(method, path, params)
+  end
+end
 
 class Search
   def initialize(query)


### PR DESCRIPTION
Hey, 👋 I am a longtime user of Spyke and I love how easy it makes it to consume an API. Recently I came across a problem where I wanted to override the `send_request` method and wondered if you'd consider making it public. 

To provide some context, at work, we have a class that inherits from `Spyke::Base` and is configured with a connection to an API. However, we're in the process of rolling out a new backend service to replace the API. The new APIs responses are formatted the same as the old API but they're available at two different hosts / endpoints.

The slight complication is that when we query the new API (v2) if it fails for any reason we'd like to fallback to querying the known good API (v1).

This is a simplified example of the code that myself and the team came up with to solve this problem.

```ruby
module V2
  class User < V1::User
    def self.send_request(method, path, params)
      super
    rescue Spyke::ConnectionError
      V1::User.send("send_request", method, path, params)
    end

    def self.connection
      V2.connection
    end
  end
end

module V1
  class User < Spyke::Base
    def self.connection
      V1.connection
    end
  end
end
```

The part I'd love to be able to refactor is `V1::User.send("send_request", method, path, params)`. If you're happy to make this method public we can refactor our code to be `User.send_request(method, path, params)`

Please let me know your thoughts 😄 
