### PR TITLE
Add support for Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ notifications:
   email: false
 rvm:
   - 2.6.6
+  - 2.7.2
+  - 3.0.0
 sudo: false

--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -105,7 +105,12 @@ module Spyke
         errors_hash.each do |field, field_errors|
           field_errors.each do |error_attributes|
             error = NormalizedValidationError.new(error_attributes)
-            errors.add(field.to_sym, error.message, error.options)
+
+            if errors.method(:add).arity == -2
+              errors.add(field.to_sym, error.message, **error.options)
+            else
+              errors.add(field.to_sym, error.message, error.options)
+            end
           end
         end
       end

--- a/spyke.gemspec
+++ b/spyke.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '>= 2.5.2'
 
   spec.add_development_dependency 'actionpack', '>= 4.0.0'
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler', '>= 1.6'
   spec.add_development_dependency 'coveralls', '~> 0.7'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-line'


### PR DESCRIPTION
* Keyword argument changes were breaking in Ruby 3.0 and we need to be explicit about passing them to receivers. To maintain compatibility with Rails 4.x (which used an `options = {}` argument instead), we check the arity of the receiving method and send the appropriate message.

* Bundler 1.x is not supported in newer Ruby versions, so we need to specify a minimum version.

* Test on Ruby 2.7 and 3.0 (both had slight differences in keyword arguments handling)