### PR TITLE
fix params with stringified keys that are part of the URL getting appended to query

### DIFF
--- a/lib/spyke/relation.rb
+++ b/lib/spyke/relation.rb
@@ -5,7 +5,7 @@ module Spyke
     include Enumerable
 
     attr_reader :klass
-    attr_accessor :params
+    attr_reader :params
     delegate :to_ary, :[], :any?, :empty?, :last, :size, :metadata, to: :find_some
 
     def initialize(klass, options = {})
@@ -19,6 +19,10 @@ module Spyke
       relation = clone
       relation.params = params.merge(conditions)
       relation
+    end
+
+    def params=(params)
+      @params = params.symbolize_keys
     end
 
     def with(uri)

--- a/lib/spyke/version.rb
+++ b/lib/spyke/version.rb
@@ -1,3 +1,3 @@
 module Spyke
-  VERSION = '5.4.2'
+  VERSION = '5.4.3'
 end

--- a/test/scopes_test.rb
+++ b/test/scopes_test.rb
@@ -61,6 +61,14 @@ module Spyke
       assert_requested endpoint
     end
 
+    def test_where_with_stringified_keys
+      endpoint = stub_request(:get, 'http://sushi.com/recipes/1/image')
+
+      RecipeImage.where("recipe_id" => 1).to_a
+
+      assert_requested endpoint
+    end
+
     def test_chainable_class_method
       endpoint = stub_request(:get, 'http://sushi.com/recipes?status=published&per_page=3')
 


### PR DESCRIPTION
## What

### Before

```rb
Base.with("recipes/:recipe_id/image").where("recipe_id" => 1).to_a
# => GET /recipes/1/image?recipe_id=1
```

### After

```rb
Base.with("recipes/:recipe_id/image").where("recipe_id" => 1).to_a
# => GET /recipes/1/image
```