### PR TITLE
move send_request back to private

### DIFF
--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -41,20 +41,20 @@ module Spyke
         @uri ||= uri_template || default_uri
       end
 
-      def send_request(method, path, params)
-        connection.send(method) do |request|
-          if method == :get
-            request.url path.to_s, params
-          else
-            request.url path.to_s
-            request.body = params
-          end
-        end
-      rescue Faraday::ConnectionFailed, Faraday::TimeoutError
-        raise ConnectionError
-      end
-
       private
+
+        def send_request(method, path, params)
+          connection.send(method) do |request|
+            if method == :get
+              request.url path.to_s, params
+            else
+              request.url path.to_s
+              request.body = params
+            end
+          end
+        rescue Faraday::ConnectionFailed, Faraday::TimeoutError
+          raise ConnectionError
+        end
 
         def scoped_request(method)
           uri = new.uri

--- a/lib/spyke/version.rb
+++ b/lib/spyke/version.rb
@@ -1,3 +1,3 @@
 module Spyke
-  VERSION = '5.4.3'
+  VERSION = '6.0.0'
 end

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -119,10 +119,10 @@ end
 class OtherRecipe < OtherApi
   uri 'recipes/(:id)'
 
-  def self.send_request(method, path, params)
+  def self.request(method, path, params)
     super
   rescue Spyke::ConnectionError
-    Recipe.send_request(method, path, params)
+    Recipe.request(method, path, params)
   end
 end
 


### PR DESCRIPTION
For https://github.com/balvig/spyke/pull/116, it seemed like we overlooked the `request` method already being public, and therefore already providing a way to achieve the fallback behavior described. 🙇 

cc @karlentwistle 