### PR TITLE
allow custom URIs with query params

### DIFF
--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -46,7 +46,8 @@ module Spyke
         def send_request(method, path, params)
           connection.send(method) do |request|
             if method == :get
-              request.url path.to_s, params
+              path, params = merge_query_params(path, params)
+              request.url path, params
             else
               request.url path.to_s
               request.body = params
@@ -54,6 +55,13 @@ module Spyke
           end
         rescue Faraday::ConnectionFailed, Faraday::TimeoutError
           raise ConnectionError
+        end
+
+        def merge_query_params(path, params)
+          parsed_uri = Addressable::URI.parse(path.to_s)
+          path = parsed_uri.path
+          params = params.merge(parsed_uri.query_values || {})
+          [path, params]
         end
 
         def scoped_request(method)

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -241,6 +241,15 @@ module Spyke
       assert_requested endpoint
     end
 
+
+    def test_using_where_with_custom_uri_including_query_params
+      endpoint = stub_request(:get, 'http://sushi.com/featured_ingredients?filter[group_id]=1&filter[status]=published')
+
+      Group.new(id: 1).featured_ingredients.where(filter: { status: 'published' }).to_a
+
+      assert_requested endpoint
+    end
+
     def test_path_inferred_from_name
       endpoint = stub_request(:get, 'http://sushi.com/recipes/1/gallery_images')
       Recipe.new(id: 1).gallery_images.to_a

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -79,6 +79,7 @@ end
 
 class Group < Spyke::Base
   has_many :ingredients, uri: nil
+  has_many :featured_ingredients, uri: 'featured_ingredients?filter[group_id]=:group_id', class_name: "Ingredient"
   accepts_nested_attributes_for :ingredients
 
   def self.build_default


### PR DESCRIPTION
## What 

Fixes scenario where a custom uri containing a query string would get overriden by the usage of `where`

### Before

```rb
class Group < Spyke::Base
  has_many :ingredients, uri: "ingredients?filter[group_id]=:group_id"
end

## Before
Group.new(id: 1).ingredients.where(filter: { status: "published" })
# => GET /ingredients?filter[status]=published

## After
Group.new(id: 1).ingredients.where(filter: { status: "published" })
# => GET /ingredients?filter[group_id]?=1&filter[status]=published
```

## Why

Addresses https://github.com/balvig/spyke/issues/71#issuecomment-843329292

## How

The problem was that when passing in a uri with a query param _and_ a set of params to the Faraday `request` method, it would give the `params` priority when composing the query string:

https://github.com/balvig/spyke/blob/51ccec7b0394d58d9c05fbf451278578f9e65ea2/lib/spyke/http.rb#L50

By merging them ourselves _before_ the Faraday stage, we can prevent that from happening:

https://github.com/balvig/spyke/blob/51ccec7b0394d58d9c05fbf451278578f9e65ea2/lib/spyke/http.rb#L49-L50