### PR TITLE
ActionPack (Rails) 7 support

### DIFF
--- a/lib/spyke/associations/builder.rb
+++ b/lib/spyke/associations/builder.rb
@@ -29,10 +29,22 @@ module Spyke
           candidates << type_name
 
           candidates.each do |candidate|
-            constant = ActiveSupport::Dependencies.safe_constantize(candidate)
+            constant = safe_constantize(candidate)
             return constant if candidate == constant.to_s
           end
           raise NameError.new("uninitialized constant #{candidates.first}", candidates.first)
+        end
+
+        # ActiveSupport < 7.0
+        if ActiveSupport::Dependencies.respond_to?(:safe_constantize)
+          def safe_constantize(name)
+            ActiveSupport::Dependencies.safe_constantize(name)
+          end
+        # ActiveSupport >= 7.0
+        else
+          def safe_constantize(name)
+            ActiveSupport::Inflector.safe_constantize(name)
+          end
         end
     end
   end

--- a/lib/spyke/associations/builder.rb
+++ b/lib/spyke/associations/builder.rb
@@ -29,22 +29,10 @@ module Spyke
           candidates << type_name
 
           candidates.each do |candidate|
-            constant = safe_constantize(candidate)
+            constant = candidate.safe_constantize
             return constant if candidate == constant.to_s
           end
           raise NameError.new("uninitialized constant #{candidates.first}", candidates.first)
-        end
-
-        # ActiveSupport < 7.0
-        if ActiveSupport::Dependencies.respond_to?(:safe_constantize)
-          def safe_constantize(name)
-            ActiveSupport::Dependencies.safe_constantize(name)
-          end
-        # ActiveSupport >= 7.0
-        else
-          def safe_constantize(name)
-            ActiveSupport::Inflector.safe_constantize(name)
-          end
         end
     end
   end


### PR DESCRIPTION
Rails 7 removed `ActiveSupport::Dependencies.safe_constantize` ([commit](https://github.com/rails/rails/commit/38e82daee81e1447d1e66ce7d5fe733ecbbc27d5)), which Spyke depends on, essentially breaking Spyke on Rails 7.

This PR fixes it by detecting if the old method still exists, and reverting to the new `ActiveSupport::Inflector.safe_constantize` if not.