### PR TITLE
Add bin/console executable for debugging with Pry

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'spyke'
+require 'pry'
+
+Pry.start

--- a/bin/console
+++ b/bin/console
@@ -4,7 +4,9 @@ require 'bundler/setup'
 require 'spyke'
 require 'pry'
 
-# Require support files via `TEST=true bin/console`
-require_relative '../test/support/fixtures.rb' if ENV['TEST']
+# Require support files via `bin/console -t`
+if ARGV.any? { |o| %w(-t --test).include? o }
+  require_relative '../test/support/fixtures.rb'
+end
 
 Pry.start

--- a/bin/console
+++ b/bin/console
@@ -4,4 +4,7 @@ require 'bundler/setup'
 require 'spyke'
 require 'pry'
 
+# Require support files via `TEST=true bin/console`
+require_relative '../test/support/fixtures.rb' if ENV['TEST']
+
 Pry.start

--- a/bin/console
+++ b/bin/console
@@ -7,6 +7,7 @@ require 'pry'
 # Require support files via `bin/console -t`
 if ARGV.any? { |o| %w(-t --test).include? o }
   require_relative '../test/support/fixtures.rb'
+  Spyke::Base.connection.response :logger
 end
 
 Pry.start

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -1,3 +1,5 @@
+require 'multi_json'
+
 # Dummy api
 class JSONParser < Faraday::Response::Middleware
   def parse(body)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,6 @@ require 'spyke'
 require 'minitest/autorun'
 require 'minitest/reporters'
 require 'mocha/minitest'
-require 'multi_json'
 require 'pry'
 
 # Require support files


### PR DESCRIPTION
The title sums it up! I was tinkering around with some of Spyke's internals, and found this `bin/console` executable useful. Since `pry` is already a development dependency, I chose to use it instead of a standard `irb` console.

### Usage
- run `./bin/console` in your command line and an interactive Pry session will begin. Here you will have access to the Spyke module and everything it includes in `lib/spyke.rb`
- Optionally, run `./bin/console -t` to load `test/support/fixtures.rb` and have access to all fixture classes