### PR TITLE
Fix: PerThreadRegistry is deprecated

### DIFF
--- a/lib/spyke/scope_registry.rb
+++ b/lib/spyke/scope_registry.rb
@@ -3,26 +3,26 @@ module Spyke
     # https://github.com/balvig/spyke/pull/128
     if ActiveSupport::VERSION::MAJOR >= 7
       class << self
-        delegate :value_for, :set_value_for, to: :instance
-
-        def instance
-          ActiveSupport::IsolatedExecutionState[:spyke_scope_registry] ||= new
-        end
+        delegate :value_for, :set_value_for, to: :new
       end
+
+      thread_mattr_accessor :registry
     else
       extend ActiveSupport::PerThreadRegistry
+
+      attr_accessor :registry
     end
 
     def initialize
-      @registry = Hash.new { |hash, key| hash[key] = {} }
+      self.registry ||= Hash.new { |hash, key| hash[key] = {} }
     end
 
     def value_for(scope_type, variable_name)
-      @registry[scope_type][variable_name]
+      registry[scope_type][variable_name]
     end
 
     def set_value_for(scope_type, variable_name, value)
-      @registry[scope_type][variable_name] = value
+      registry[scope_type][variable_name] = value
     end
   end
 end

--- a/lib/spyke/scope_registry.rb
+++ b/lib/spyke/scope_registry.rb
@@ -1,11 +1,16 @@
 module Spyke
   class ScopeRegistry
-    class << self
-      delegate :value_for, :set_value_for, to: :instance
+    # https://github.com/balvig/spyke/pull/128
+    if ActiveSupport::VERSION::MAJOR >= 7
+      class << self
+        delegate :value_for, :set_value_for, to: :instance
 
-      def instance
-        ActiveSupport::IsolatedExecutionState[:spyke_scope_registry] ||= new
+        def instance
+          ActiveSupport::IsolatedExecutionState[:spyke_scope_registry] ||= new
+        end
       end
+    else
+      extend ActiveSupport::PerThreadRegistry
     end
 
     def initialize

--- a/lib/spyke/scope_registry.rb
+++ b/lib/spyke/scope_registry.rb
@@ -1,6 +1,12 @@
 module Spyke
   class ScopeRegistry
-    extend ActiveSupport::PerThreadRegistry
+    class << self
+      delegate :value_for, :set_value_for, to: :instance
+
+      def instance
+        ActiveSupport::IsolatedExecutionState[:spyke_scope_registry] ||= new
+      end
+    end
 
     def initialize
       @registry = Hash.new { |hash, key| hash[key] = {} }

--- a/test/scope_registry_test.rb
+++ b/test/scope_registry_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+module Spyke
+  class ScopeRegistryTest < MiniTest::Test
+    def test_setting_and_fetching_values
+      ScopeRegistry.set_value_for('foo', 'bar', 1)
+
+      assert_equal 1, ScopeRegistry.value_for('foo', 'bar')
+    end
+  end
+end


### PR DESCRIPTION
Fixes deprecation warning:

```
DEPRECATION WARNING: ActiveSupport::PerThreadRegistry is deprecated and will be removed in Rails 7.1.
Use `Module#thread_mattr_accessor` instead.   
```

Reference: https://github.com/rails/rails/pull/43673