### PR TITLE
Merge test coverage data for different versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,22 @@ jobs:
       - run:
           name: Run tests
           command: bundle exec rake
+  coverage:
+    docker:
+      - image: cimg/ruby:3.0.0
+    steps:
+      - checkout
+      - ruby/bundle-install
+      - run:
+          name: Push coverage to coveralls
+          command: bundle exec rake coveralls:push
 
 workflows:
   tests:
     jobs:
       - build:
           matrix:
+            alias: Rails 5
             parameters:
               rails_version: ["~> 4.0"]
               ruby_version: ["2.6.6"]
@@ -49,11 +59,15 @@ workflows:
               ruby_version: ["2.6.6", "2.7.2"]
       - build:
           matrix:
+            alias: Rails 6
             parameters:
               rails_version: ["~> 6.0"]
               ruby_version: ["2.6.6", "2.7.2", "3.0.0"]
       - build:
           matrix:
+            alias: Rails 7
             parameters:
               rails_version: ["~> 7.0"]
               ruby_version: ["2.7.2", "3.0.0"]
+      - coverage:
+          requires: ["Rails 5", "Rails 6", "Rails 7"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ version: 2.1
 # See: https://circleci.com/docs/2.0/orb-intro/
 orbs:
   ruby: circleci/ruby@0.1.2
+  coveralls: coveralls/coveralls@1.0.6
+  node: circleci/node@5.0.0
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
@@ -21,6 +23,7 @@ jobs:
     executor: ruby/default
     environment:
       RAILS_TEST_VERSION: << parameters.rails_version >>
+      EUID: 0 # not sure why this is needed, but sudo npm fails
     steps:
       - checkout
       - run:
@@ -33,27 +36,29 @@ jobs:
       - run:
           name: Run tests
           command: bundle exec rake
+      - node/install:
+          node-version: 10.0.0
+      - coveralls/upload:
+          parallel: true
   coverage:
     docker:
-      - image: cimg/ruby:3.0.0
+      - image: circleci/node:10.0.0
     steps:
-      - checkout
-      - ruby/bundle-install
-      - run:
-          name: Push coverage to coveralls
-          command: bundle exec rake coveralls:push
+      - coveralls/upload:
+          parallel_finished: true
 
 workflows:
   tests:
     jobs:
       - build:
           matrix:
-            alias: Rails 5
+            alias: Rails 4
             parameters:
               rails_version: ["~> 4.0"]
               ruby_version: ["2.6.6"]
       - build:
           matrix:
+            alias: Rails 5
             parameters:
               rails_version: ["~> 5.0"]
               ruby_version: ["2.6.6", "2.7.2"]
@@ -70,4 +75,4 @@ workflows:
               rails_version: ["~> 7.0"]
               ruby_version: ["2.7.2", "3.0.0"]
       - coverage:
-          requires: ["Rails 5", "Rails 6", "Rails 7"]
+          requires: ["Rails 4", "Rails 5", "Rails 6", "Rails 7"]

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,3 @@ Rake::TestTask.new do |t|
   t.libs << 'test'
   t.pattern = 'test/*_test.rb'
 end
-
-require 'coveralls/rake/task'
-Coveralls::RakeTask.new

--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,6 @@ Rake::TestTask.new do |t|
   t.libs << 'test'
   t.pattern = 'test/*_test.rb'
 end
+
+require 'coveralls/rake/task'
+Coveralls::RakeTask.new

--- a/spyke.gemspec
+++ b/spyke.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'actionpack', ENV.fetch('RAILS_TEST_VERSION', '>= 4.0.0')
   spec.add_development_dependency 'bundler', '>= 1.6'
-  spec.add_development_dependency 'coveralls_reborn', '~> 0.23.0'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-line'
   spec.add_development_dependency 'minitest-reporters'
@@ -34,5 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'multi_json'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'simplecov-lcov'
   spec.add_development_dependency 'webmock'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,6 @@
 # Coverage
 require 'coveralls'
-Coveralls.wear!
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+Coveralls.wear_merged!
 SimpleCov.start do
   add_filter 'test'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,10 @@
-# Coverage
-require 'coveralls'
-Coveralls.wear_merged!
+require 'simplecov'
+require 'simplecov-lcov'
+SimpleCov::Formatter::LcovFormatter.config do |c|
+  c.report_with_single_file = true
+  c.single_report_path = 'coverage/lcov.info'
+end
+SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
 SimpleCov.start do
   add_filter 'test'
 end


### PR DESCRIPTION
Uses https://circleci.com/developer/orbs/orb/coveralls/coveralls to merge coverage data from all versions of Rails/Ruby.