### PR TITLE
Remove Ruby/Rails warnings

### DIFF
--- a/lib/spyke/scope_registry.rb
+++ b/lib/spyke/scope_registry.rb
@@ -1,17 +1,19 @@
 module Spyke
-  class ScopeRegistry
-    extend ActiveSupport::PerThreadRegistry
-
-    def initialize
-      @registry = Hash.new { |hash, key| hash[key] = {} }
-    end
+  module ScopeRegistry
+    extend self
 
     def value_for(scope_type, variable_name)
-      @registry[scope_type][variable_name]
+      registry[scope_type][variable_name]
     end
 
     def set_value_for(scope_type, variable_name, value)
-      @registry[scope_type][variable_name] = value
+      registry[scope_type][variable_name] = value
+    end
+
+    private
+
+    def registry
+      Thread.current[to_s] ||= Hash.new { |hash, key| hash[key] = {} }
     end
   end
 end

--- a/test/custom_request_test.rb
+++ b/test/custom_request_test.rb
@@ -70,7 +70,7 @@ module Spyke
 
     def test_multiple_apis_with_custom_fallback
       fallback_endpoint = stub_request(:get, 'http://sushi.com/recipes')
-      primary_endpoint = stub_request(:get, 'http://sashimi.com/recipes').to_timeout
+      _primary_endpoint = stub_request(:get, 'http://sashimi.com/recipes').to_timeout
       OtherRecipe.all.to_a
       assert_requested fallback_endpoint
     end


### PR DESCRIPTION
Just a couple of quick fixes, I noticed this while doing a Rails upgrade.