### PR TITLE
Add support for both Faraday 1.x and 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in spyke.gemspec
 gemspec
+
+gem "faraday_middleware" # to support Faraday 1.x

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ class JSONParser < Faraday::Response::Middleware
 end
 
 Spyke::Base.connection = Faraday.new(url: 'http://api.com') do |c|
-  c.request   :json
+  c.request   :json # if using Faraday 1.x, please add `faraday_middleware` to your dependencies first
   c.use       JSONParser
   c.adapter   Faraday.default_adapter
 end

--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -1,5 +1,16 @@
 require 'faraday'
-require 'faraday_middleware'
+if Gem.loaded_specs["faraday"].version < Gem::Version.new("2.0")
+  begin
+    require 'faraday_middleware'
+  rescue LoadError => e
+    puts <<~MSG
+      Please add `faraday_middleware` to your Gemfile when using Faraday 1.x. Alternatively,
+      upgrade to Faraday `~> 2` to avoid this dependency.
+    MSG
+    raise e
+  end
+end
+
 require 'spyke/config'
 require 'spyke/path'
 require 'spyke/result'

--- a/spyke.gemspec
+++ b/spyke.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', ENV.fetch('RAILS_TEST_VERSION', '>= 4.0.0')
   spec.add_dependency 'activemodel', ENV.fetch('RAILS_TEST_VERSION', '>= 4.0.0')
-  spec.add_dependency 'faraday', '>= 0.9.0', '< 2.0'
-  spec.add_dependency 'faraday_middleware', '>= 0.9.1', '< 2.0'
+  spec.add_dependency 'faraday', '>= 0.9.0', '< 3.0'
   spec.add_dependency 'addressable', '>= 2.5.2'
 
   spec.add_development_dependency 'actionpack', ENV.fetch('RAILS_TEST_VERSION', '>= 4.0.0')


### PR DESCRIPTION
Changelog: https://github.com/lostisland/faraday/blob/main/UPGRADING.md#faraday-20

To support Faraday 2.x, the `faraday_middleware` library is no longer required for sending/receiving JSON bodies, and each individual adapter is shipped as a separate gem (e.g. faraday-patron).

Since it's quite hard to update Faraday everywhere (because it is a dependency of many different gems), we should support both versions in Spyke to allow users to upgrade Faraday on their terms.