### PR TITLE
Update gemspec to avoid binstubs being installed on system path

### DIFF
--- a/lib/spyke/version.rb
+++ b/lib/spyke/version.rb
@@ -1,3 +1,3 @@
 module Spyke
-  VERSION = '7.1.0'
+  VERSION = '7.1.1'
 end

--- a/spyke.gemspec
+++ b/spyke.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
## What

- Closes #142 
- Reference: https://bundler.io/blog/2015/03/20/moving-bins-to-exe.html