### PR TITLE
Add params to DELETE

### DIFF
--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -43,7 +43,7 @@ module Spyke
 
         def send_request(method, path, params)
           connection.send(method) do |request|
-            if method == :get
+            if [:get, :delete].include?(method)
               path, params = merge_query_params(path, params)
               request.url path, params
             else

--- a/lib/spyke/orm.rb
+++ b/lib/spyke/orm.rb
@@ -71,8 +71,8 @@ module Spyke
       end
     end
 
-    def destroy
-      self.attributes = delete
+    def destroy(params = {})
+      self.attributes = delete(params)
     end
 
     def update(new_attributes)

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -168,6 +168,14 @@ module Spyke
       assert_equal({ 'foto' => { 'url' => 'bob.jpg' } }, Cookbook::Photo.new(url: 'bob.jpg').to_params)
     end
 
+    def test_destroy_with_params
+      endpoint = stub_request(:delete, 'http://sushi.com/recipes/1?cascade=true').to_return_json(result: { id: 1, deleted: true })
+      recipe = Recipe.new(id: 1)
+      recipe.destroy(cascade: true)
+      assert recipe.deleted
+      assert_requested endpoint
+    end
+
     def test_destroy
       endpoint = stub_request(:delete, 'http://sushi.com/recipes/1').to_return_json(result: { id: 1, deleted: true })
       recipe = Recipe.new(id: 1)


### PR DESCRIPTION
I am trying to use this REST API which takes query params on DELETE

https://docs.camunda.org/manual/7.5/reference/rest/deployment/delete-deployment/

Made these changes and ran tests locally. But to run tests locally I had to rename `MiniTest` to `Minitest`. I am not familiar with Minitest to know about this.