### PR TITLE
Address deprecated log formatting

### DIFF
--- a/lib/spyke/instrumentation/log_subscriber.rb
+++ b/lib/spyke/instrumentation/log_subscriber.rb
@@ -19,8 +19,18 @@ module Spyke
         self.class.runtime += event.duration
         name = '%s (%.1fms)' % ["Spyke", event.duration]
         details = "#{event.payload[:method].upcase} #{event.payload[:url]} [#{event.payload[:status]}]"
-        debug "  #{color(name, GREEN, true)}  #{color(details, BOLD, true)}"
+        debug "  #{color(name, GREEN, backwards_compatible_bold)}  #{color(details, nil, backwards_compatible_bold)}"
       end
+
+      private
+
+        def backwards_compatible_bold
+          if ActiveSupport.gem_version < Gem::Version.new("7.1.0")
+            true
+          else
+            { bold: true }
+          end
+        end
     end
   end
 end


### PR DESCRIPTION
## What

- Closes https://github.com/balvig/spyke/issues/150
- Addresses deprecation warning in Rails 7.1:

```
DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. color("my text", :red, bold: true)).
```

Thanks to @emptyflask for spotting/sharing this! 🙏 
