### PR TITLE
Add minimum Ruby Version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ workflows:
           matrix:
             alias: Rails 4
             parameters:
-              rails_version: ["~> 4"]
+              rails_version: ["~> 4.0"]
               ruby_version: ["2.6.9"]
               faraday_version: ["< 2.0"]
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ workflows:
           matrix:
             alias: Rails 4
             parameters:
-              rails_version: ["~> 4.0"]
+              rails_version: ["~> 4"]
               ruby_version: ["2.6.9"]
               faraday_version: ["< 2.0"]
       - build:

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,8 @@ gemspec
 if ENV['FARADAY_TEST_VERSION'] == '< 2.0'
   gem 'faraday_middleware'
 end
+
+# https://github.com/ruby/bigdecimal#which-version-should-you-select
+if ENV['RAILS_TEST_VERSION'] == '~> 4.0'
+  gem 'bigdecimal', '1.3.5'
+end

--- a/spyke.gemspec
+++ b/spyke.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.6.9'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'activesupport', ENV.fetch('RAILS_TEST_VERSION', '>= 4.0.0')
   spec.add_dependency 'activemodel', ENV.fetch('RAILS_TEST_VERSION', '>= 4.0.0')

--- a/spyke.gemspec
+++ b/spyke.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.6.9'
 
   spec.add_dependency 'activesupport', ENV.fetch('RAILS_TEST_VERSION', '>= 4.0.0')
   spec.add_dependency 'activemodel', ENV.fetch('RAILS_TEST_VERSION', '>= 4.0.0')

--- a/spyke.gemspec
+++ b/spyke.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.6.9'
+
   spec.add_dependency 'activesupport', ENV.fetch('RAILS_TEST_VERSION', '>= 4.0.0')
   spec.add_dependency 'activemodel', ENV.fetch('RAILS_TEST_VERSION', '>= 4.0.0')
   spec.add_dependency 'faraday', ENV.fetch('FARADAY_TEST_VERSION', '>= 1.0.0'), '< 3.0'


### PR DESCRIPTION
## What

Closes https://github.com/balvig/spyke/issues/155
The minimum version tested in CI is `2.6.9`, so setting `2.6` as the lower minimum.