### PR TITLE
Revert "Add params to DELETE"

### DIFF
--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -43,7 +43,7 @@ module Spyke
 
         def send_request(method, path, params)
           connection.send(method) do |request|
-            if [:get, :delete].include?(method)
+            if method == :get
               path, params = merge_query_params(path, params)
               request.url path, params
             else

--- a/lib/spyke/orm.rb
+++ b/lib/spyke/orm.rb
@@ -71,8 +71,8 @@ module Spyke
       end
     end
 
-    def destroy(params = {})
-      self.attributes = delete(params)
+    def destroy
+      self.attributes = delete
     end
 
     def update(new_attributes)

--- a/lib/spyke/version.rb
+++ b/lib/spyke/version.rb
@@ -1,3 +1,3 @@
 module Spyke
-  VERSION = '7.2.1'
+  VERSION = '7.2.2'
 end

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -168,14 +168,6 @@ module Spyke
       assert_equal({ 'foto' => { 'url' => 'bob.jpg' } }, Cookbook::Photo.new(url: 'bob.jpg').to_params)
     end
 
-    def test_destroy_with_params
-      endpoint = stub_request(:delete, 'http://sushi.com/recipes/1?cascade=true').to_return_json(result: { id: 1, deleted: true })
-      recipe = Recipe.new(id: 1)
-      recipe.destroy(cascade: true)
-      assert recipe.deleted
-      assert_requested endpoint
-    end
-
     def test_destroy
       endpoint = stub_request(:delete, 'http://sushi.com/recipes/1').to_return_json(result: { id: 1, deleted: true })
       recipe = Recipe.new(id: 1)


### PR DESCRIPTION
## What

Reverts balvig/spyke#145

## Why

balvig/spyke#145 unintentionally introduced an unintentional breaking change for client sending parameters in the body on DELETE requests.