### PR TITLE
Enable params on DELETE via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,17 @@ class Post < Spyke::Base
 end
 ```
 
+### Allow parameters on delete request
+
+If you need to allow custom parameters on the `DELETE` action, this can be enabled:
+
+```ruby
+Spyke::Base.allow_params_on_delete = true
+
+User.new(id: 1).destroy(customer_id: 9)
+# => DELETE http://api.com/users/1?customer_id=9
+```
+
 ### Log output
 
 When used with Rails, Spyke will automatically output helpful

--- a/lib/spyke/http.rb
+++ b/lib/spyke/http.rb
@@ -10,6 +10,7 @@ module Spyke
 
     included do
       class_attribute :connection, instance_accessor: false
+      class_attribute :allow_params_on_delete, instance_accessor: false, default: false
     end
 
     module ClassMethods
@@ -43,7 +44,7 @@ module Spyke
 
         def send_request(method, path, params)
           connection.send(method) do |request|
-            if method == :get
+            if params_in_url?(method)
               path, params = merge_query_params(path, params)
               request.url path, params
             else
@@ -86,6 +87,13 @@ module Spyke
 
         def default_uri
           "#{model_name.element.pluralize}(/:#{primary_key})"
+        end
+
+        def params_in_url?(method)
+          return true if method == :get
+          return true if allow_params_on_delete && method == :delete
+
+          false
         end
     end
 

--- a/lib/spyke/orm.rb
+++ b/lib/spyke/orm.rb
@@ -71,8 +71,8 @@ module Spyke
       end
     end
 
-    def destroy
-      self.attributes = delete
+    def destroy(params = {})
+      self.attributes = delete(params)
     end
 
     def update(new_attributes)

--- a/lib/spyke/version.rb
+++ b/lib/spyke/version.rb
@@ -1,3 +1,3 @@
 module Spyke
-  VERSION = '7.2.2'
+  VERSION = '7.2.3'
 end

--- a/test/orm_test.rb
+++ b/test/orm_test.rb
@@ -176,6 +176,23 @@ module Spyke
       assert_requested endpoint
     end
 
+    def test_destroy_without_params
+      endpoint = stub_request(:delete, 'http://sushi.com/recipes/1').to_return_json(result: { id: 1, deleted: true })
+      recipe = Recipe.new(id: 1)
+      recipe.destroy(customer_id: 9)
+      assert recipe.deleted
+      assert_requested endpoint
+    end
+
+    def test_destroy_with_params
+      Spyke::Base.allow_params_on_delete = true
+      endpoint = stub_request(:delete, 'http://sushi.com/recipes/1?customer_id=9').to_return_json(result: { id: 1, deleted: true })
+      recipe = Recipe.new(id: 1)
+      recipe.destroy(customer_id: 9)
+      assert recipe.deleted
+      assert_requested endpoint
+    end
+
     def test_destroy_class_method
       endpoint = stub_request(:delete, 'http://sushi.com/recipes/1')
       Recipe.destroy(1)


### PR DESCRIPTION
### What
Allow custom params on DELETE via config.

### Why
The https://github.com/balvig/spyke/pull/157 reverted the possibility of passing params on DELETE action. However, our app uses shard databases and requires some extra params to identify which shard will be hit. In this change, we allow custom params on DELETE via config.