### PR TITLE
Fix filename for multipart requests

### DIFF
--- a/lib/spyke/attributes.rb
+++ b/lib/spyke/attributes.rb
@@ -12,7 +12,7 @@ module Spyke
         case
         when value.is_a?(Spyke::Base)         then value.attributes.to_params
         when value.is_a?(Array)               then value.map { |v| parse_value(v) }
-        when value.respond_to?(:content_type) then Faraday::Multipart::FilePart.new(value.path, value.content_type)
+        when value.respond_to?(:content_type) then Faraday::Multipart::FilePart.new(value.path, value.content_type, value.original_filename)
         else value
         end
       end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -134,10 +134,11 @@ module Spyke
     end
 
     def test_converting_files_to_faraday_io
-      Faraday::Multipart::FilePart.stubs(:new).with('/photo.jpg', 'image/jpeg').returns('UploadIO')
+      Faraday::Multipart::FilePart.stubs(:new).with('/photo.jpg', 'image/jpeg', 'photo.jpg').returns('UploadIO')
       file = mock
       file.stubs(:path).returns('/photo.jpg')
       file.stubs(:content_type).returns('image/jpeg')
+      file.stubs(:original_filename).returns('photo.jpg')
 
       recipe = Recipe.new(image: Image.new(file: file))
 


### PR DESCRIPTION
I received an incorrect file name from Tempfile in API POST and this solves the problem:

Before:
```
#<Multipart::Post::UploadIO:0x0000000131bd8e40
 @content_type="application/pdf",
 @io=#<File:/var/folders/pj/v2_fjn1x14g6ltszhng1vm780000gn/T/2025-10-07_1131180842_20251000183.pdf20251022-11937-oot4>,
 @local_path="/var/folders/pj/v2_fjn1x14g6ltszhng1vm780000gn/T/2025-10-07_1131180842_20251000183.pdf20251022-11937-oot4",
 @opts={},
 @original_filename="2025-10-07_1131180842_20251000183.pdf20251022-11937-oot4">
```

After my fix:
```
#<Multipart::Post::UploadIO:0x00000001301c3a28
 @content_type="application/pdf",
 @io=#<File:/var/folders/pj/v2_fjn1x14g6ltszhng1vm780000gn/T/2025-10-07_1131180842_20251000183.pdf20251022-12992-xip0mm>,
 @local_path="/var/folders/pj/v2_fjn1x14g6ltszhng1vm780000gn/T/2025-10-07_1131180842_20251000183.pdf20251022-12992-xip0mm",
 @opts={},
 @original_filename="2025-10-07_1131180842_20251000183.pdf">
```